### PR TITLE
Make GLintptr and GLsizeiptr match those from QtOpenGL /usr/i686-w64-…

### DIFF
--- a/angleproject/mingw-w64/PKGBUILD
+++ b/angleproject/mingw-w64/PKGBUILD
@@ -9,7 +9,7 @@
 
 pkgname=mingw-w64-angleproject
 pkgver=2.1.r5707.5858f7e
-pkgrel=1
+pkgrel=2
 pkgdesc='ANGLE project (mingw-w64)'
 arch=('any')
 url='https://chromium.googlesource.com/angle/angle/+/master/README.md'
@@ -23,14 +23,16 @@ source=('angleproject::git+https://chromium.googlesource.com/angle/angle#commit=
         'libEGL_mingw32.def'
         'libGLESv2_mingw32.def'
         'entry_points_shader.cpp'
-        'provide_mbstowcs_s_for_xp.patch')
+        'provide_mbstowcs_s_for_xp.patch'
+        'fix-compatibility-with-qtopengl-and-qtwebkit.patch')
 sha256sums=('SKIP'
             'SKIP'
             '895c62846e6784dcc33171523a452cb474010d3fc9e7c351c27b8add4e9930ab'
             'fb04f30b904760d32c4c0b733d0a0b44359855db1fde9e7f5ca7d0b8b1be3e56'
             '3186d913a5fb483d2ae568068453e494d52df8f3f23f09d16afbbf916a63e4a4'
             'ad347c9732f8897497aa51b8969a0e01cd8cd4ebb9a0e873a2ff47c210f1d46c'
-            '57b16254c23dbd312dbbe0495a177690809b916c2f3d8b3bbf2dd405274d518c')
+            '57b16254c23dbd312dbbe0495a177690809b916c2f3d8b3bbf2dd405274d518c'
+            '5e4ca559a0d9efb00cbe097c8ae0102bb3132a78e68d590a5826ff86f2a6ccf2')
 _architectures="i686-w64-mingw32 x86_64-w64-mingw32"
 
 #pkgver() {
@@ -64,6 +66,10 @@ prepare() {
 
   # provide own implementation of mbstowcs_s for Windows XP support
   patch -p1 -i "${srcdir}/provide_mbstowcs_s_for_xp.patch"
+
+  # Fixes definition of GLsizeiptr and GLintptr to match that used by
+  # qopenglext.h in qt5-base. Fixes build of qt5-base-dynamic and qt5-webkit.
+  patch -p1 -i "${srcdir}/fix-compatibility-with-qtopengl-and-qtwebkit.patch"
 
   # executing .bat scripts on Linux is a no-go so make this a no-op
   echo "" > src/copy_compiler_dll.bat

--- a/angleproject/mingw-w64/fix-compatibility-with-qtopengl-and-qtwebkit.patch
+++ b/angleproject/mingw-w64/fix-compatibility-with-qtopengl-and-qtwebkit.patch
@@ -1,0 +1,30 @@
+diff -Naur angleproject.orig/include/KHR/khrplatform.h angleproject/include/KHR/khrplatform.h
+--- angleproject.orig/include/KHR/khrplatform.h	2016-10-26 16:15:14.000000000 -0500
++++ angleproject/include/KHR/khrplatform.h	2016-11-02 17:02:26.685185043 -0500
+@@ -228,17 +228,22 @@
+  * to be the only LLP64 architecture in current use.
+  */
+ #ifdef _WIN64
+-typedef signed   long long int khronos_intptr_t;
++//typedef signed   long long int khronos_intptr_t;
+ typedef unsigned long long int khronos_uintptr_t;
+-typedef signed   long long int khronos_ssize_t;
++//typedef signed   long long int khronos_ssize_t;
+ typedef unsigned long long int khronos_usize_t;
+ #else
+-typedef signed   long  int     khronos_intptr_t;
++//typedef signed   long  int     khronos_intptr_t;
+ typedef unsigned long  int     khronos_uintptr_t;
+-typedef signed   long  int     khronos_ssize_t;
++//typedef signed   long  int     khronos_ssize_t;
+ typedef unsigned long  int     khronos_usize_t;
+ #endif
+ 
++// Make this compatible with QTOpenGL and QtWebkit.
++// It seems that ptrdiff_t is the right size on WIN32 and WIN64.
++typedef ptrdiff_t khronos_intptr_t;
++typedef ptrdiff_t khronos_ssize_t;
++
+ #if KHRONOS_SUPPORT_FLOAT
+ /*
+  * Float type

--- a/qt5-multimedia/mingw-w64/0002-Fix-build-wtih-angle-enabled.patch
+++ b/qt5-multimedia/mingw-w64/0002-Fix-build-wtih-angle-enabled.patch
@@ -1,0 +1,16 @@
+diff -Naur qtmultimedia-opensource-src-5.7.0.orig/src/plugins/common/evr/evrd3dpresentengine.cpp qtmultimedia-opensource-src-5.7.0/src/plugins/common/evr/evrd3dpresentengine.cpp
+--- qtmultimedia-opensource-src-5.7.0.orig/src/plugins/common/evr/evrd3dpresentengine.cpp	2016-06-08 06:38:56.000000000 -0500
++++ qtmultimedia-opensource-src-5.7.0/src/plugins/common/evr/evrd3dpresentengine.cpp	2016-11-03 14:07:13.172478447 -0500
+@@ -49,9 +49,9 @@
+ #include <private/qmediaopenglhelper_p.h>
+ 
+ #ifdef MAYBE_ANGLE
+-# include <qtgui/qguiapplication.h>
+-# include <qpa/qplatformnativeinterface.h>
+-# include <qopenglfunctions.h>
++# include <QtGui/qguiapplication.h>
++# include <QtGui/qpa/qplatformnativeinterface.h>
++# include <QtGui/qopenglfunctions.h>
+ # include <EGL/eglext.h>
+ #endif
+ 

--- a/qt5-multimedia/mingw-w64/PKGBUILD
+++ b/qt5-multimedia/mingw-w64/PKGBUILD
@@ -11,7 +11,7 @@
 _qt_module=qtmultimedia
 pkgname=mingw-w64-qt5-multimedia
 pkgver=5.7.0
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc='Classes for audio, video, radio and camera functionality (mingw-w64)'
 depends=('mingw-w64-qt5-base' 'mingw-w64-qt5-declarative')
@@ -22,9 +22,11 @@ license=('GPL3' 'LGPL' 'FDL' 'custom')
 url='https://www.qt.io/'
 _pkgfqn="${_qt_module}-opensource-src-${pkgver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver:0:3}/${pkgver}/submodules/${_pkgfqn}.tar.xz"
-        '0001-Recorder-includes-to-prevent-conflict-with-vsnprintf.patch')
+        '0001-Recorder-includes-to-prevent-conflict-with-vsnprintf.patch'
+        '0002-Fix-build-wtih-angle-enabled.patch')
 md5sums=('44c1b9a1dfb0e8b13f2d9571829500ee'
-         '530551aefa1310f6ff740663b84751cd')
+         '530551aefa1310f6ff740663b84751cd'
+         'e4b435f51063d8d3868efb8224c89ff8')
 
 _architectures='i686-w64-mingw32 x86_64-w64-mingw32'
 [[ $NO_STATIC_LIBS ]] || \


### PR DESCRIPTION
…mingw32/include/GLES2/gl2.h so that QtOpenGL and QtWebKit compile.

When building mingw-w64-qtwebkit with mingw-w64-base-dynamic, it fails with following error. This patch gets us past that error. It still fails to complete at the link stage. I am not sure how to fix that particular issue.

```
i686-w64-mingw32-g++ -c -Wall -Wextra -Wreturn-type -Wchar-subscripts -Wformat-security -Wreturn-type -Wno-unused-parameter -Wno-sign-compare -Wno-switch -Wno-switch-enum -Wundef -Wmissing-noreturn -Winit-self -O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 -fno-keep-inline-dllexport -fpch-preprocess -Wno-c++0x-compat -g1 -fno-strict-aliasing -std=gnu++11 -fno-exceptions -frtti -DUNICODE -DQT_NO_MTDEV -DQT_NO_DYNAMIC_LIBRARY -DQT_NO_LIBUDEV -DQT_NO_EVDEV -DQT_NO_TSLIB -DQT_NO_LIBINPUT -DSH_GLSL_OUTPUT=SH_GLSL_COMPATIBILITY_OUTPUT -DBUILDING_QT__=1 -DNDEBUG -DENABLE_3D_RENDERING=1 -DENABLE_ACCELERATED_2D_CANVAS=1 -DENABLE_BLOB=1 -DENABLE_CANVAS_PATH=1 -DENABLE_CHANNEL_MESSAGING=1 -DENABLE_CSS_BOX_DECORATION_BREAK=1 -DENABLE_CSS_COMPOSITING=1 -DENABLE_CSS_EXCLUSIONS=1 -DENABLE_CSS_FILTERS=1 -DENABLE_CSS_IMAGE_SET=1 -DENABLE_CSS_REGIONS=1 -DENABLE_CSS_SHAPES=1 -DENABLE_CSS_STICKY_POSITION=1 -DENABLE_CSS_TRANSFORMS_ANIMATIONS_UNPREFIXED=1 -DENABLE_DATALIST_ELEMENT=1 -DENABLE_DETAILS_ELEMENT=1 -DENABLE_DEVICE_ORIENTATION=1 -DENABLE_DOWNLOAD_ATTRIBUTE=1 -DENABLE_FAST_MOBILE_SCROLLING=1 -DENABLE_FILTERS=1 -DENABLE_FTPDIR=1 -DENABLE_FULLSCREEN_API=1 -DENABLE_GEOLOCATION=1 -DENABLE_GESTURE_EVENTS=1 -DENABLE_ICONDATABASE=1 -DENABLE_IFRAME_SEAMLESS=1 -DENABLE_INDEXED_DATABASE=1 -DENABLE_INPUT_TYPE_COLOR=1 -DENABLE_INSPECTOR=1 -DENABLE_INSPECTOR_SERVER=1 -DENABLE_JAVASCRIPT_DEBUGGER=1 -DENABLE_LEGACY_NOTIFICATIONS=1 -DENABLE_LEGACY_VIEWPORT_ADAPTION=1 -DENABLE_LEGACY_VENDOR_PREFIXES=1 -DENABLE_LEGACY_WEB_AUDIO=1 -DENABLE_LINK_PREFETCH=1 -DENABLE_METER_ELEMENT=1 -DENABLE_MHTML=1 -DENABLE_NOTIFICATIONS=1 -DENABLE_ORIENTATION_EVENTS=1 -DENABLE_PAGE_VISIBILITY_API=1 -DENABLE_PROGRESS_ELEMENT=1 -DENABLE_RESOLUTION_MEDIA_QUERY=1 -DENABLE_REQUEST_ANIMATION_FRAME=1 -DENABLE_SHARED_WORKERS=1 -DENABLE_SMOOTH_SCROLLING=1 -DENABLE_SQL_DATABASE=1 -DENABLE_SUBPIXEL_LAYOUT=1 -DENABLE_SVG=1 -DENABLE_SVG_FONTS=1 -DENABLE_TOUCH_ADJUSTMENT=1 -DENABLE_TOUCH_EVENTS=1 -DENABLE_VIDEO_TRACK=1 -DENABLE_VIEW_MODE_CSS_MEDIA=1 -DENABLE_WEB_SOCKETS=1 -DENABLE_WEB_TIMING=1 -DENABLE_WORKERS=1 -DENABLE_XHR_TIMEOUT=1 -DWTF_USE_TILED_BACKING_STORE=1 -DWTF_USE_CROSS_PLATFORM_CONTEXT_MENUS=1 -DHAVE_QTQUICK=1 -DHAVE_QTPRINTSUPPORT=1 -DHAVE_QSTYLE=1 -DHAVE_QTTESTLIB=1 -DHAVE_QTPOSITIONING=1 -DHAVE_QTSENSORS=1 -DWTF_USE_LIBXML2=1 -DENABLE_XSLT=1 -DWTF_USE_ZLIB=1 -DWTF_USE_WEBP=1 -DWTF_USE_LIBJPEG=1 -DWTF_USE_LIBPNG=1 -DENABLE_NETSCAPE_PLUGIN_API=1 -DPLUGIN_ARCHITECTURE_UNSUPPORTED=1 -DWTF_USE_3D_GRAPHICS=1 -DENABLE_WEBGL=1 -DHAVE_DYNAMICGL=1 -DENABLE_VIDEO=1 -DWTF_USE_QT_MULTIMEDIA=1 -DHAVE_SQLITE3=1 -DENABLE_TOUCH_SLIDER=1 -DWTF_USE_LEVELDB=1 -DENABLE_BATTERY_STATUS=0 -DENABLE_CANVAS_PROXY=0 -DENABLE_CSP_NEXT=0 -DENABLE_CSS_GRID_LAYOUT=0 -DENABLE_CSS_HIERARCHIES=0 -DENABLE_CSS_IMAGE_ORIENTATION=0 -DENABLE_CSS_IMAGE_RESOLUTION=0 -DENABLE_CSS_SHADERS=0 -DENABLE_CSS_VARIABLES=0 -DENABLE_CSS3_CONDITIONAL_RULES=0 -DENABLE_CSS3_TEXT=0 -DENABLE_CSS3_TEXT_LINE_BREAK=0 -DENABLE_DASHBOARD_SUPPORT=0 -DENABLE_DATAGRID=0 -DENABLE_DATA_TRANSFER_ITEMS=0 -DENABLE_DIRECTORY_UPLOAD=0 -DENABLE_FILE_SYSTEM=0 -DENABLE_FONT_LOAD_EVENTS=0 -DENABLE_GAMEPAD=0 -DENABLE_HIGH_DPI_CANVAS=0 -DENABLE_INPUT_SPEECH=0 -DENABLE_INPUT_TYPE_DATE=0 -DENABLE_INPUT_TYPE_DATETIME_INCOMPLETE=0 -DENABLE_INPUT_TYPE_DATETIMELOCAL=0 -DENABLE_INPUT_TYPE_MONTH=0 -DENABLE_INPUT_TYPE_TIME=0 -DENABLE_INPUT_TYPE_WEEK=0 -DENABLE_LEGACY_CSS_VENDOR_PREFIXES=0 -DENABLE_MATHML=0 -DENABLE_MEDIA_SOURCE=0 -DENABLE_MEDIA_STATISTICS=0 -DENABLE_MEDIA_STREAM=0 -DENABLE_MICRODATA=0 -DENABLE_MOUSE_CURSOR_SCALE=0 -DENABLE_NAVIGATOR_CONTENT_UTILS=0 -DENABLE_NETWORK_INFO=0 -DENABLE_NOSNIFF=0 -DENABLE_PROXIMITY_EVENTS=0 -DENABLE_QUOTA=0 -DENABLE_RESOURCE_TIMING=0 -DENABLE_SCRIPTED_SPEECH=0 -DENABLE_SECCOMP_FILTERS=0 -DENABLE_SHADOW_DOM=0 -DENABLE_STYLE_SCOPED=0 -DENABLE_TEMPLATE_ELEMENT=0 -DENABLE_TEXT_AUTOSIZING=0 -DENABLE_THREADED_HTML_PARSER=0 -DENABLE_TOUCH_ICON_LOADING=0 -DENABLE_USER_TIMING=0 -DENABLE_VIBRATION=0 -DENABLE_WEB_AUDIO=0 -DSTATICALLY_LINKED_WITH_angle -DSTATICALLY_LINKED_WITH_leveldb -DSTATICALLY_LINKED_WITH_JavaScriptCore -DSTATICALLY_LINKED_WITH_WTF -DBUILDING_WebCore -DBUILDING_WEBKIT -DQT_ASCII_CAST_WARNINGS -DQT_STATIC -DQT_DESIGNER_STATIC -DQT_NO_EXCEPTIONS -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_SQL_LIB -DQT_SENSORS_LIB -DQT_CORE_LIB -DGL_GLEXT_PROTOTYPES -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore -I. -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/filesystem -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/geolocation -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/indexeddb -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/mediasource -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/navigatorcontentutils -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/notifications -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/proximity -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/quota -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/webaudio -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/webdatabase -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/websockets -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/accessibility -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bindings -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bindings/generic -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bridge -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bridge/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/css -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/dom -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/dom/default -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/editing -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/fileapi -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/history -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/canvas -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/forms -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/parser -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/shadow -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/track -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/inspector -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/appcache -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/archive -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/cache -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/icon -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/mathml -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page/animation -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page/scrolling -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page/scrolling/coordinatedgraphics -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/animation -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/audio -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/cpu/arm -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/cpu/arm/filters -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/filters -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/filters/texmap -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/opengl -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/opentype -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/surfaces -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/texmap -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/texmap/coordinated -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/transforms -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/bmp -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/ico -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/gif -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/jpeg -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/png -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/webp -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/leveldb -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/mock -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/network -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/network/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/sql -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/text -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/text/transcoder -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/plugins -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/mathml -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/shapes -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/style -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/svg -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/storage -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg/animation -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg/graphics -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg/graphics/filters -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg/properties -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/testing -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/websockets -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/workers -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/xml -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/xml/parser -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/ThirdParty -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bridge/jsc -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bindings/js -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bridge/c -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/testing/js -Igenerated -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/win -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/plugins/win -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/win -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/win -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/gpu -I/usr/i686-w64-mingw32/sys-root/mingw/include/GLSLANG -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/gpu -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/archive/mhtml -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/build-i686-w64-mingw32-static/Source/include -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/ThirdParty/leveldb/include -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/ThirdParty/leveldb -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WTF -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/assembler -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/bytecode -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/bytecompiler -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/heap -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/dfg -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/debugger -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/disassembler -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/interpreter -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/jit -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/llint -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/parser -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/profiler -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/runtime -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/tools -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/yarr -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/API -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/ForwardingHeaders -I../JavaScriptCore/generated -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/build-i686-w64-mingw32-static/Source/JavaScriptCore/generated/LLIntOffsetsExtractor.exe -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WTF -I/usr/i686-w64-mingw32/include -I/usr/i686-w64-mingw32/include/libxml2 -I/usr/i686-w64-mingw32/include/qt/QtGui/5.7.0 -I/usr/i686-w64-mingw32/include/qt/QtGui/5.7.0/QtGui -I/usr/i686-w64-mingw32/include/qt -I/usr/i686-w64-mingw32/include/qt/QtMultimedia -I/usr/i686-w64-mingw32/include/qt/QtGui -I/usr/i686-w64-mingw32/include/qt/QtNetwork -I/usr/i686-w64-mingw32/include/qt/QtSql -I/usr/i686-w64-mingw32/include/qt/QtCore/5.7.0 -I/usr/i686-w64-mingw32/include/qt/QtCore/5.7.0/QtCore -I/usr/i686-w64-mingw32/include/qt/QtSensors -I/usr/i686-w64-mingw32/include/qt/QtCore -I.moc/release -I/usr/i686-w64-mingw32/include/freetype2 -I/usr/i686-w64-mingw32/include -I/usr/i686-w64-mingw32/include/harfbuzz -I/usr/i686-w64-mingw32/include/glib-2.0 -I/usr/i686-w64-mingw32/lib/glib-2.0/include -I/usr/i686-w64-mingw32/include -I/usr/i686-w64-mingw32/include/dbus-1.0 -I/usr/i686-w64-mingw32/lib/dbus-1.0/include -I/usr/i686-w64-mingw32/lib/qt/mkspecs/win32-g++  -o .obj/release/RenderGrid.o /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/RenderGrid.cpp
i686-w64-mingw32-g++ -c -Wall -Wextra -Wreturn-type -Wchar-subscripts -Wformat-security -Wreturn-type -Wno-unused-parameter -Wno-sign-compare -Wno-switch -Wno-switch-enum -Wundef -Wmissing-noreturn -Winit-self -O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 -fno-keep-inline-dllexport -fpch-preprocess -Wno-c++0x-compat -g1 -fno-strict-aliasing -std=gnu++11 -fno-exceptions -frtti -DUNICODE -DQT_NO_MTDEV -DQT_NO_DYNAMIC_LIBRARY -DQT_NO_LIBUDEV -DQT_NO_EVDEV -DQT_NO_TSLIB -DQT_NO_LIBINPUT -DSH_GLSL_OUTPUT=SH_GLSL_COMPATIBILITY_OUTPUT -DBUILDING_QT__=1 -DNDEBUG -DENABLE_3D_RENDERING=1 -DENABLE_ACCELERATED_2D_CANVAS=1 -DENABLE_BLOB=1 -DENABLE_CANVAS_PATH=1 -DENABLE_CHANNEL_MESSAGING=1 -DENABLE_CSS_BOX_DECORATION_BREAK=1 -DENABLE_CSS_COMPOSITING=1 -DENABLE_CSS_EXCLUSIONS=1 -DENABLE_CSS_FILTERS=1 -DENABLE_CSS_IMAGE_SET=1 -DENABLE_CSS_REGIONS=1 -DENABLE_CSS_SHAPES=1 -DENABLE_CSS_STICKY_POSITION=1 -DENABLE_CSS_TRANSFORMS_ANIMATIONS_UNPREFIXED=1 -DENABLE_DATALIST_ELEMENT=1 -DENABLE_DETAILS_ELEMENT=1 -DENABLE_DEVICE_ORIENTATION=1 -DENABLE_DOWNLOAD_ATTRIBUTE=1 -DENABLE_FAST_MOBILE_SCROLLING=1 -DENABLE_FILTERS=1 -DENABLE_FTPDIR=1 -DENABLE_FULLSCREEN_API=1 -DENABLE_GEOLOCATION=1 -DENABLE_GESTURE_EVENTS=1 -DENABLE_ICONDATABASE=1 -DENABLE_IFRAME_SEAMLESS=1 -DENABLE_INDEXED_DATABASE=1 -DENABLE_INPUT_TYPE_COLOR=1 -DENABLE_INSPECTOR=1 -DENABLE_INSPECTOR_SERVER=1 -DENABLE_JAVASCRIPT_DEBUGGER=1 -DENABLE_LEGACY_NOTIFICATIONS=1 -DENABLE_LEGACY_VIEWPORT_ADAPTION=1 -DENABLE_LEGACY_VENDOR_PREFIXES=1 -DENABLE_LEGACY_WEB_AUDIO=1 -DENABLE_LINK_PREFETCH=1 -DENABLE_METER_ELEMENT=1 -DENABLE_MHTML=1 -DENABLE_NOTIFICATIONS=1 -DENABLE_ORIENTATION_EVENTS=1 -DENABLE_PAGE_VISIBILITY_API=1 -DENABLE_PROGRESS_ELEMENT=1 -DENABLE_RESOLUTION_MEDIA_QUERY=1 -DENABLE_REQUEST_ANIMATION_FRAME=1 -DENABLE_SHARED_WORKERS=1 -DENABLE_SMOOTH_SCROLLING=1 -DENABLE_SQL_DATABASE=1 -DENABLE_SUBPIXEL_LAYOUT=1 -DENABLE_SVG=1 -DENABLE_SVG_FONTS=1 -DENABLE_TOUCH_ADJUSTMENT=1 -DENABLE_TOUCH_EVENTS=1 -DENABLE_VIDEO_TRACK=1 -DENABLE_VIEW_MODE_CSS_MEDIA=1 -DENABLE_WEB_SOCKETS=1 -DENABLE_WEB_TIMING=1 -DENABLE_WORKERS=1 -DENABLE_XHR_TIMEOUT=1 -DWTF_USE_TILED_BACKING_STORE=1 -DWTF_USE_CROSS_PLATFORM_CONTEXT_MENUS=1 -DHAVE_QTQUICK=1 -DHAVE_QTPRINTSUPPORT=1 -DHAVE_QSTYLE=1 -DHAVE_QTTESTLIB=1 -DHAVE_QTPOSITIONING=1 -DHAVE_QTSENSORS=1 -DWTF_USE_LIBXML2=1 -DENABLE_XSLT=1 -DWTF_USE_ZLIB=1 -DWTF_USE_WEBP=1 -DWTF_USE_LIBJPEG=1 -DWTF_USE_LIBPNG=1 -DENABLE_NETSCAPE_PLUGIN_API=1 -DPLUGIN_ARCHITECTURE_UNSUPPORTED=1 -DWTF_USE_3D_GRAPHICS=1 -DENABLE_WEBGL=1 -DHAVE_DYNAMICGL=1 -DENABLE_VIDEO=1 -DWTF_USE_QT_MULTIMEDIA=1 -DHAVE_SQLITE3=1 -DENABLE_TOUCH_SLIDER=1 -DWTF_USE_LEVELDB=1 -DENABLE_BATTERY_STATUS=0 -DENABLE_CANVAS_PROXY=0 -DENABLE_CSP_NEXT=0 -DENABLE_CSS_GRID_LAYOUT=0 -DENABLE_CSS_HIERARCHIES=0 -DENABLE_CSS_IMAGE_ORIENTATION=0 -DENABLE_CSS_IMAGE_RESOLUTION=0 -DENABLE_CSS_SHADERS=0 -DENABLE_CSS_VARIABLES=0 -DENABLE_CSS3_CONDITIONAL_RULES=0 -DENABLE_CSS3_TEXT=0 -DENABLE_CSS3_TEXT_LINE_BREAK=0 -DENABLE_DASHBOARD_SUPPORT=0 -DENABLE_DATAGRID=0 -DENABLE_DATA_TRANSFER_ITEMS=0 -DENABLE_DIRECTORY_UPLOAD=0 -DENABLE_FILE_SYSTEM=0 -DENABLE_FONT_LOAD_EVENTS=0 -DENABLE_GAMEPAD=0 -DENABLE_HIGH_DPI_CANVAS=0 -DENABLE_INPUT_SPEECH=0 -DENABLE_INPUT_TYPE_DATE=0 -DENABLE_INPUT_TYPE_DATETIME_INCOMPLETE=0 -DENABLE_INPUT_TYPE_DATETIMELOCAL=0 -DENABLE_INPUT_TYPE_MONTH=0 -DENABLE_INPUT_TYPE_TIME=0 -DENABLE_INPUT_TYPE_WEEK=0 -DENABLE_LEGACY_CSS_VENDOR_PREFIXES=0 -DENABLE_MATHML=0 -DENABLE_MEDIA_SOURCE=0 -DENABLE_MEDIA_STATISTICS=0 -DENABLE_MEDIA_STREAM=0 -DENABLE_MICRODATA=0 -DENABLE_MOUSE_CURSOR_SCALE=0 -DENABLE_NAVIGATOR_CONTENT_UTILS=0 -DENABLE_NETWORK_INFO=0 -DENABLE_NOSNIFF=0 -DENABLE_PROXIMITY_EVENTS=0 -DENABLE_QUOTA=0 -DENABLE_RESOURCE_TIMING=0 -DENABLE_SCRIPTED_SPEECH=0 -DENABLE_SECCOMP_FILTERS=0 -DENABLE_SHADOW_DOM=0 -DENABLE_STYLE_SCOPED=0 -DENABLE_TEMPLATE_ELEMENT=0 -DENABLE_TEXT_AUTOSIZING=0 -DENABLE_THREADED_HTML_PARSER=0 -DENABLE_TOUCH_ICON_LOADING=0 -DENABLE_USER_TIMING=0 -DENABLE_VIBRATION=0 -DENABLE_WEB_AUDIO=0 -DSTATICALLY_LINKED_WITH_angle -DSTATICALLY_LINKED_WITH_leveldb -DSTATICALLY_LINKED_WITH_JavaScriptCore -DSTATICALLY_LINKED_WITH_WTF -DBUILDING_WebCore -DBUILDING_WEBKIT -DQT_ASCII_CAST_WARNINGS -DQT_STATIC -DQT_DESIGNER_STATIC -DQT_NO_EXCEPTIONS -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_SQL_LIB -DQT_SENSORS_LIB -DQT_CORE_LIB -DGL_GLEXT_PROTOTYPES -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore -I. -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/filesystem -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/geolocation -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/indexeddb -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/mediasource -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/navigatorcontentutils -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/notifications -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/proximity -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/quota -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/webaudio -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/webdatabase -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/Modules/websockets -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/accessibility -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bindings -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bindings/generic -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bridge -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bridge/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/css -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/dom -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/dom/default -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/editing -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/fileapi -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/history -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/canvas -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/forms -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/parser -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/shadow -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/html/track -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/inspector -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/appcache -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/archive -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/cache -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/icon -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/mathml -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page/animation -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page/scrolling -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/page/scrolling/coordinatedgraphics -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/animation -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/audio -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/cpu/arm -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/cpu/arm/filters -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/filters -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/filters/texmap -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/opengl -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/opentype -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/surfaces -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/texmap -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/texmap/coordinated -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/transforms -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/bmp -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/ico -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/gif -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/jpeg -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/png -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/image-decoders/webp -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/leveldb -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/mock -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/network -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/network/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/qt -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/sql -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/text -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/text/transcoder -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/plugins -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/mathml -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/shapes -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/style -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/svg -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/storage -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg/animation -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg/graphics -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg/graphics/filters -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/svg/properties -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/testing -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/websockets -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/workers -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/xml -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/xml/parser -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/ThirdParty -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bridge/jsc -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bindings/js -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/bridge/c -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/testing/js -Igenerated -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/win -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/plugins/win -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/win -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/win -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/gpu -I/usr/i686-w64-mingw32/sys-root/mingw/include/GLSLANG -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/gpu -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/loader/archive/mhtml -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/build-i686-w64-mingw32-static/Source/include -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/ThirdParty/leveldb/include -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/ThirdParty/leveldb -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WTF -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/assembler -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/bytecode -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/bytecompiler -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/heap -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/dfg -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/debugger -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/disassembler -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/interpreter -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/jit -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/llint -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/parser -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/profiler -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/runtime -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/tools -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/yarr -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/API -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/JavaScriptCore/ForwardingHeaders -I../JavaScriptCore/generated -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/build-i686-w64-mingw32-static/Source/JavaScriptCore/generated/LLIntOffsetsExtractor.exe -I/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WTF -I/usr/i686-w64-mingw32/include -I/usr/i686-w64-mingw32/include/libxml2 -I/usr/i686-w64-mingw32/include/qt/QtGui/5.7.0 -I/usr/i686-w64-mingw32/include/qt/QtGui/5.7.0/QtGui -I/usr/i686-w64-mingw32/include/qt -I/usr/i686-w64-mingw32/include/qt/QtMultimedia -I/usr/i686-w64-mingw32/include/qt/QtGui -I/usr/i686-w64-mingw32/include/qt/QtNetwork -I/usr/i686-w64-mingw32/include/qt/QtSql -I/usr/i686-w64-mingw32/include/qt/QtCore/5.7.0 -I/usr/i686-w64-mingw32/include/qt/QtCore/5.7.0/QtCore -I/usr/i686-w64-mingw32/include/qt/QtSensors -I/usr/i686-w64-mingw32/include/qt/QtCore -I.moc/release -I/usr/i686-w64-mingw32/include/freetype2 -I/usr/i686-w64-mingw32/include -I/usr/i686-w64-mingw32/include/harfbuzz -I/usr/i686-w64-mingw32/include/glib-2.0 -I/usr/i686-w64-mingw32/lib/glib-2.0/include -I/usr/i686-w64-mingw32/include -I/usr/i686-w64-mingw32/include/dbus-1.0 -I/usr/i686-w64-mingw32/lib/dbus-1.0/include -I/usr/i686-w64-mingw32/lib/qt/mkspecs/win32-g++  -o .obj/release/RenderLayerBacking.o /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/RenderLayerBacking.cpp
In file included from /usr/i686-w64-mingw32/include/angle_gl.h:13:0,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/ANGLEWebKitBridge.h:38,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/GraphicsContext3D.h:50,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/RenderLayerBacking.cpp:71:
/usr/i686-w64-mingw32/include/GLES2/gl2.h:73:25: error: conflicting declaration 'typedef khronos_ssize_t GLsizeiptr'
 typedef khronos_ssize_t GLsizeiptr;
                         ^~~~~~~~~~
In file included from /usr/i686-w64-mingw32/include/qt/QtGui/qopengl.h:130:0,
                 from /usr/i686-w64-mingw32/include/qt/QtGui/qopenglcontext.h:60,
                 from /usr/i686-w64-mingw32/include/qt/QtGui/QOpenGLContext:1,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/qt/ImageBufferDataQt.h:36,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/ImageBufferData.h:31,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/ImageBuffer.h:41,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/filters/Filter.h:26,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/FilterEffectRenderer.h:31,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/RenderLayerBacking.cpp:64:
/usr/i686-w64-mingw32/include/qt/QtGui/qopenglext.h:474:19: note: previous declaration as 'typedef ptrdiff_t GLsizeiptr'
 typedef ptrdiff_t GLsizeiptr;
                   ^~~~~~~~~~
In file included from /usr/i686-w64-mingw32/include/angle_gl.h:13:0,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/ANGLEWebKitBridge.h:38,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/GraphicsContext3D.h:50,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/RenderLayerBacking.cpp:71:
/usr/i686-w64-mingw32/include/GLES2/gl2.h:74:26: error: conflicting declaration 'typedef khronos_intptr_t GLintptr'
 typedef khronos_intptr_t GLintptr;
                          ^~~~~~~~
In file included from /usr/i686-w64-mingw32/include/qt/QtGui/qopengl.h:130:0,
                 from /usr/i686-w64-mingw32/include/qt/QtGui/qopenglcontext.h:60,
                 from /usr/i686-w64-mingw32/include/qt/QtGui/QOpenGLContext:1,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/qt/ImageBufferDataQt.h:36,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/ImageBufferData.h:31,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/ImageBuffer.h:41,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/platform/graphics/filters/Filter.h:26,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/FilterEffectRenderer.h:31,
                 from /home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/Source/WebCore/rendering/RenderLayerBacking.cpp:64:
/usr/i686-w64-mingw32/include/qt/QtGui/qopenglext.h:475:19: note: previous declaration as 'typedef ptrdiff_t GLintptr'
 typedef ptrdiff_t GLintptr;
                   ^~~~~~~~
make[3]: *** [Makefile.WebCore.Target.Release:266534: .obj/release/RenderLayerBacking.o] Error 1
make[3]: Leaving directory '/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/build-i686-w64-mingw32-static/Source/WebCore'
make[2]: *** [Makefile.WebCore.Target:34: release] Error 2
make[2]: Leaving directory '/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/build-i686-w64-mingw32-static/Source/WebCore'
make[1]: *** [Makefile.WebCore:64: sub-Target-pri-make_first-ordered] Error 2
make[1]: Leaving directory '/home/jsantiago/bb/PKGBUILDs/qt5-webkit/mingw-w64/src/qtwebkit-opensource-src-5.7.0/build-i686-w64-mingw32-static/Source/WebCore'
make: *** [Makefile:175: sub-Source-WebCore-WebCore-pro-make_first-ordered] Error 2
==> ERROR: A failure occurred in build().
    Aborting...

```