### PR TITLE
Fix linking native libs in mingw-w64-qt5-tools

### DIFF
--- a/qt5-tools/mingw-w64/PKGBUILD
+++ b/qt5-tools/mingw-w64/PKGBUILD
@@ -61,6 +61,7 @@ build() {
       # Search paths for host standard library (/usr/lib) and for Qt5Bootstrap (/usr/$_arch/lib) are not set correctly by qmake
       # hence we need insert those paths manually
       make qmake_all
+      find . -type f -iname 'Makefile' -exec sed -i "s|-L/usr/$_arch/lib -lQt5QmlDevTools -lQt5Bootstrap|-L/usr/lib /usr/$_arch/lib/libQt5QmlDevTools.so /usr/$_arch/lib/libQt5Bootstrap.so|g" {} \;
       find . -type f -iname 'Makefile' -exec sed -i "s|-L/usr/$_arch/lib -lQt5QmlDevTools|-L/usr/lib /usr/$_arch/lib/libQt5QmlDevTools.so|g" {} \;
       find . -type f -iname 'Makefile' -exec sed -i "s|-L/usr/$_arch/lib -lQt5Bootstrap|-L/usr/lib /usr/$_arch/lib/libQt5Bootstrap.so|g" {} \;
 


### PR DESCRIPTION
Also replace combined use of -lQt5QmlDevTools -lQt5Bootstrap

Might fix https://github.com/Martchus/PKGBUILDs/issues/19, not tested yet