### PR TITLE
Update nginx to 1.12.0 stable version and modules

### DIFF
--- a/nginx/custom/PKGBUILD
+++ b/nginx/custom/PKGBUILD
@@ -17,31 +17,31 @@ _cachepurge_ver="2.3"
 _cachepurge_dirname="ngx_cachepurge"
 _slowfscache_ver="1.10"
 _slowfscache_dirname="ngx_slowfscache"
-_echo_ver="v0.58"
+_echo_ver="7740e11558b530b66b469c657576f5280b7cdb1b"
 _echo_dirname="ngx_echo"
-_headersmore_ver="v0.29"
+_headersmore_ver="v0.32"
 _headersmore_dirname="ngx_headersmore"
-_uploadprogress_ver="v0.9.1"
+_uploadprogress_ver="v0.9.2"
 _uploadprogress_dirname="ngx_uploadprogress"
-_upstreamfair_hash="a18b4099fbd458111983200e098b6f0c8efed4bc"
+_upstreamfair_hash="89f72d881ba123ddcc281f9ff2535b10e35555a1"
 _upstreamfair_dirname="ngx_upstreamfair"
-_fancyindex_ver="v0.3.6"
+_fancyindex_ver="v0.4.1"
 _fancyindex_dirname="ngx_fancyindex"
 _authpam_ver="1.5.1"
 _authpam_dirname="ngx_authpam"
-_pagespeed_ver="1.11.33.0"
+_pagespeed_ver="1.11.33.4"
 _pagespeed_dirname="ngx_pagespeed"
-_rtmp_ver="v1.1.7"
+_rtmp_ver="v1.1.11"
 _rtmp_dirname="ngx_rtmp"
 _davext_ver="v0.0.3"
 _davext_dirname="ngx_davext"
-_naxsi_ver="0.54"
+_naxsi_ver="0.55.3"
 _naxsi_dirname="ngx_naxsi"
-_accesskey_ver="2.0.3"
-_accesskey_dirname="ngx_accesskey"
+#_accesskey_ver="2.0.3"
+#_accesskey_dirname="ngx_accesskey"
 
 pkgname=nginx-custom
-pkgver=1.10.3
+pkgver=1.12.0
 pkgrel=1
 pkgdesc='Lightweight HTTP server and IMAP/POP3 proxy server (with standard, additional and 3rd party modules)'
 arch=('i686' 'x86_64')
@@ -77,36 +77,37 @@ source=("nginx.sh"
         "${_uploadprogress_dirname}.source::https://github.com/masterzen/nginx-upload-progress-module/tarball/${_uploadprogress_ver}"
         "${_headersmore_dirname}.source::https://github.com/agentzh/headers-more-nginx-module/tarball/${_headersmore_ver}"
         "${_echo_dirname}.source::https://github.com/agentzh/echo-nginx-module/tarball/${_echo_ver}"
-        "${_upstreamfair_dirname}.source::https://github.com/gnosek/nginx-upstream-fair/tarball/${_upstreamfair_hash}"
+        "${_upstreamfair_dirname}.source::https://github.com/unixfox/nginx-upstream-fair/tarball/${_upstreamfair_hash}"
         "${_authpam_dirname}.tar.gz::https://github.com/stogh/ngx_http_auth_pam_module/archive/v${_authpam_ver}.tar.gz"
         "${_pagespeed_dirname}.zip::https://github.com/pagespeed/ngx_pagespeed/archive/v${_pagespeed_ver}-beta.zip"
         "psol.tar.gz::https://dl.google.com/dl/page-speed/psol/${_pagespeed_ver}.tar.gz"
         "${_rtmp_dirname}.zip::https://github.com/arut/nginx-rtmp-module/archive/${_rtmp_ver}.zip"
         "${_davext_dirname}.tar.gz::https://github.com/arut/nginx-dav-ext-module/archive/${_davext_ver}.tar.gz"
         "${_naxsi_dirname}.tar.gz::https://github.com/nbs-system/naxsi/archive/${_naxsi_ver}.tar.gz"
-        "${_accesskey_dirname}.tar.gz::https://github.com/Martchus/nginx-accesskey/archive/v${_accesskey_ver}.tar.gz"
+#        "${_accesskey_dirname}.tar.gz::https://github.com/Martchus/nginx-accesskey/archive/v${_accesskey_ver}.tar.gz"
 )
 validpgpkeys=('B0F4253373F8F6F510D42178520A9993A1C052F8') # Maxim Dounin <mdounin@mdounin.ru>
-md5sums=('204a20cb4f0b0c9db746c630d89ff4ea'
+md5sums=('d56559ed5e8cc0b1c7adbe33f2300c4c'
          '845cab784b50f1666bbf89d7435ac7af'
          'b50a547d387c4af8e9b89a5e79d22fed'
          '6696dc228a567506bca3096b5197c9db'
-         'e8f5f4beed041e63eb97f9f4f55f3085'
+         '995eb0a140455cf0cfc497e5bd7f94b3'
          'SKIP'
-         '76ac525432d459a4615a3a8638195ba9'
+         'e1dd79f0ec82415bbf8a1cb938988955'
          '3d4ec04bbc16c3b555fa20392c1119d1'
          '68a1af12d5c1218fb2b3e05ed7ff6f0c'
-         'f7dee95dbe8ada5f4d8e9d59ca1f4797'
-         '838081f1398965fbf3037bc38d1c2208'
-         '6fe61c5b44b2e338c66e1e33ff7e95ab'
-         'ac5e7f485476af70e0ee1c52016cddaf'
+         '1f8ab14fa3dd171bf3b6c7b18783bc22'
+         'c9cdf7f9a27361159b282e1faa618094'
+         '1c2b08220f5118e3f16026fc530797cb'
+         '403e3c72c33ed275b203226ee1927e46'
          '1e0bbd4535386970d63f51064626bc9a'
-         '7756ea8925cefe8ed531b3d5b50ca9d2'
-         'c503b01cb92f95a5548cf86a2e7415e5'
-         'a81e63cd4cf28eaf0c87d27c44e4c44a'
+         '6bdd65c5929b35d06d6df9c7f2fa6360'
+         'd5ccb4cab81edc32ff99a2a46e8a9ffc'
+         'b471efc97b9602c5b4087756c9295496'
          '2cb502dbda335be4ebd5fed0b3182bae'
-         '1bc31058991268e4cfdb44e9b6d8b3b3'
-         '9d5dc36ffe87cee59dfa8d4931fb528e')
+         'b50f6d41aa017cbfcab577ed70d7b3b7'
+#         '9d5dc36ffe87cee59dfa8d4931fb528e'
+         )
 
 build() {
   local _src_dir="${srcdir}/${_pkgname}-${pkgver}"
@@ -117,11 +118,11 @@ build() {
   mv openresty-headers-more-nginx-module-* ${_headersmore_dirname}
   mv openresty-echo-nginx-module-* ${_echo_dirname}
   mv masterzen-nginx-upload-progress-module-* ${_uploadprogress_dirname}
-  mv gnosek-nginx-upstream-fair-* ${_upstreamfair_dirname}
+  mv unixfox-nginx-upstream-fair-* ${_upstreamfair_dirname}
   mv ngx_http_auth_pam_module-${_authpam_ver} ${_authpam_dirname}
   mv ngx_pagespeed-* ${_pagespeed_dirname}
   mv psol ${_pagespeed_dirname}/
-  mv nginx-accesskey* ${_accesskey_dirname}
+#  mv nginx-accesskey* ${_accesskey_dirname}
   mv nginx-rtmp-module* ${_rtmp_dirname}
   mv nginx-dav-ext-module* ${_davext_dirname}
   mv naxsi* ${_naxsi_dirname}
@@ -188,7 +189,6 @@ build() {
     --add-module=../${_fancyindex_dirname} \
     --add-module=../${_authpam_dirname} \
     --add-module=../${_pagespeed_dirname} \
-    --add-module=../${_accesskey_dirname} \
     --add-module=../${_rtmp_dirname} \
     --add-module=../${_davext_dirname}
   make


### PR DESCRIPTION
Nginx 1.12.0 stable version is out since 12 April 2017, changelog here: https://nginx.org/en/CHANGES-1.12

I came across with some bugs while compiling so I updated all the modules.
I removed temporarily the module from the PKGBUILD because I can't compile the accesskey module due to this error that I don't know how to resolve:

```
cc -c -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong   -D_GLIBCXX_USE_CXX11_ABI=0  -I src/core -I src/event -I src/event/modules -I src/os/unix -I ../ngx_rtmp -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/http/modules/perl -I ../ngx_pagespeed/psol/include -I ../ngx_pagespeed/psol/include/third_party/chromium/src -I ../ngx_pagespeed/psol/include/third_party/google-sparsehash/src -I ../ngx_pagespeed/psol/include/third_party/google-sparsehash/gen/arch/linux/x64/include -I ../ngx_pagespeed/psol/include/third_party/protobuf/src/src -I ../ngx_pagespeed/psol/include/third_party/re2/src -I ../ngx_pagespeed/psol/include/out/Debug/obj/gen -I ../ngx_pagespeed/psol/include/out/Debug/obj/gen/protoc_out/instaweb -I ../ngx_pagespeed/psol/include/third_party/apr/src/include -I ../ngx_pagespeed/psol/include/third_party/aprutil/src/include -I ../ngx_pagespeed/psol/include/third_party/apr/gen/arch/linux/x64/include -I ../ngx_pagespeed/psol/include/third_party/aprutil/gen/arch/linux/x64/include -I ../ngx_pagespeed/psol/include/url -I src/mail -I src/stream \
	-o objs/addon/ngx_accesskey/ngx_http_accesskey_module.o \
	../ngx_accesskey/ngx_http_accesskey_module.c
../ngx_accesskey/ngx_http_accesskey_module.c:14:17: fatal error: md5.h: No such file or directory
 #include <md5.h>
                 ^
compilation terminated.
make[1]: *** [objs/Makefile:2285: objs/addon/ngx_accesskey/ngx_http_accesskey_module.o] Error 1
```

Apart from that everything is working great on my side, proof:
```
[unixfox@aresrpg ~]$ nginx -V
nginx version: nginx/1.12.0
built with OpenSSL 1.1.0e  16 Feb 2017
TLS SNI support enabled
configure arguments: --prefix=/etc/nginx --conf-path=/etc/nginx/nginx.conf --sbin-path=/usr/bin/nginx --pid-path=/run/nginx.pid --lock-path=/run/nginx.lock --http-client-body-temp-path=/var/spool/nginx/client_body_temp --http-proxy-temp-path=/var/spool/nginx/proxy_temp --http-fastcgi-temp-path=/var/spool/nginx/fastcgi_temp --http-uwsgi-temp-path=/var/spool/nginx/uwsgi_temp --http-scgi-temp-path=/var/spool/nginxscgi_temp --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log --user=http --group=http --with-debug --with-ipv6 --with-pcre-jit --with-file-aio --with-mail --with-mail_ssl_module --with-stream --with-stream_ssl_module --with-threads --add-module=../ngx_naxsi/naxsi_src/ --with-http_ssl_module --with-http_stub_status_module --with-http_dav_module --with-http_gzip_static_module --with-http_realip_module --with-http_addition_module --with-http_auth_request_module --with-http_xslt_module --with-http_image_filter_module --with-http_sub_module --with-http_v2_module --with-mail --with-mail_ssl_module --with-stream --with-stream_ssl_module --with-threads --with-http_flv_module --with-http_mp4_module --with-http_random_index_module --with-http_secure_link_module --with-http_slice_module --with-http_perl_module --with-http_degradation_module --with-http_geoip_module --with-http_gunzip_module --with-http_auth_request_module --add-module=../ngx_cachepurge --add-module=../ngx_echo --add-module=../ngx_headersmore --add-module=../ngx_slowfscache --add-module=../ngx_uploadprogress --add-module=../ngx_upstreamfair --add-module=../ngx_fancyindex --add-module=../ngx_authpam --add-module=../ngx_pagespeed --add-module=../ngx_rtmp --add-module=../ngx_davext
```