### PR TITLE
fix org name

### DIFF
--- a/gogs/default/PKGBUILD
+++ b/gogs/default/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Thomas Laroche <tho.laroche@gmail.com>
 
 _pkgname=gogs
-_orga=go-${_pkgname}
+_orga=gogits
 _gourl=github.com/gogits/$_pkgname
 
 pkgname=$_pkgname


### PR DESCRIPTION
404 - https://github.com/go-gogs/gogs/archive/v0.11.19.tar.gz
gogits, not go-gogs