### PR TITLE
Apply patch only once

### DIFF
--- a/qt5-base/mingw-w64-dynamic/PKGBUILD
+++ b/qt5-base/mingw-w64-dynamic/PKGBUILD
@@ -212,7 +212,7 @@ prepare() {
 
   # Apply patches; further descriptions can be found in patch files itself
   for patch in "$srcdir/"*.patch; do
-    patch -p1 -i "$patch"
+    patch -Np1 -i "$patch" || true
   done
 
   # Make sure the Qt5 build system uses our external ANGLE library


### PR DESCRIPTION
Apply patch only once and don't stop package build if the patch fail, specially when resuming from a previous build. And makepkg will inform if the patch is broken anyways.