### PR TITLE
Update PKGBUILD makepedends for Gogs

### DIFF
--- a/gogs/default/PKGBUILD
+++ b/gogs/default/PKGBUILD
@@ -22,7 +22,7 @@ optdepends=('sqlite: SQLite support'
             'redis: Redis support'
             'memcached: MemCached support'
             'openssh: GIT over SSH support')
-makedepends=('go>=1.3')
+makedepends=('go>=1.3' 'patch' 'gcc')
 conflicts=("$_pkgname-bin" "$_pkgname-git" "$_pkgname-dev-git")
 options=('!strip')
 backup=("etc/$_pkgname/app.ini")


### PR DESCRIPTION
patch and gcc are required for making this package. Gcc because sqlite3 driver is cgo package and requires gcc to compile (https://github.com/mattn/go-sqlite3)