### PR TITLE
Adding mxedeployqt to PKGBUILDs

### DIFF
--- a/mxedeployqt/git/PKGBUILD
+++ b/mxedeployqt/git/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Dinesh Manajipet <saidinesh5@gmail.com>
+
+_pkgname=mxedeployqt
+pkgname=$_pkgname-git
+pkgver=0.1
+pkgrel=1
+pkgdesc="A little tool to substitute the missing windeployqt in mxe. It grabs all the qt dependencies your program may need, in order to deploy it.; MIT license - git development version"
+arch=('i686' 'x86_64')
+url="https://github.com/saidinesh5/mxedeployqt"
+license=('MIT')
+groups=()
+depends=(python)
+makedepends=('git')
+optdepends=()
+provides=("$_pkgname")
+conflicts=("$_pkgname")
+source=("$_pkgname::git+https://github.com/saidinesh5/mxedeployqt.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_pkgname"
+  git describe --tags | sed 's|-|.|g'
+}
+
+package() {
+  cd "$srcdir/$_pkgname"
+  mkdir -p "$pkgdir/usr/bin/"
+  install -Dm 755 "$srcdir/$_pkgname/mxedeployqt" "$pkgdir/usr/bin/"
+}
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
This is a little tool to substitute the missing windeployqt in mxe.
It grabs all the qt dependencies your program may need, in order to
deploy it.