### PR TITLE
Update kirigami2 to 5.69.0

### DIFF
--- a/extra-cmake-modules/mingw-w64/PKGBUILD
+++ b/extra-cmake-modules/mingw-w64/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=mingw-w64-extra-cmake-modules
-pkgver=5.60.0
+pkgver=5.69.0
 pkgrel=1
 arch=(any)
 pkgdesc="Extra modules and scripts for CMake (mingw-w64)"
@@ -11,7 +11,7 @@ url="https://community.kde.org/Frameworks"
 source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/extra-cmake-modules-${pkgver}.tar.xz"{,.sig}
 "set-AUTOSTATICPLUGINS.patch"
 "05aa27dc0e14dab407379a4d22f895e9eff13cc0.patch")
-sha256sums=('2bd9da815de98d5908d3371815df963d305c828f90ba1a076f38543876690248'
+sha256sums=('dacc8e0be8605b6c609ea35bda2d87bf06e1d228bcbf8957b0f0230c4a888359'
             'SKIP'
             '30bdcedab402c69ea0db3460f5a23cbd226a5cd1e12b13926b8a65df773e14a0'
             '7e44cf56a8274c8166eaf02e60c2d34e5048992a7e3c8309b998b762a394e909')

--- a/kirigami2/android-aarch64/PKGBUILD
+++ b/kirigami2/android-aarch64/PKGBUILD
@@ -12,7 +12,7 @@ _android_platform=22
 _prefix=/opt/android-libs/$_pkg_arch
 
 pkgname=android-$_pkg_arch-$_pkgname
-pkgver=5.62.0
+pkgver=5.69.0
 pkgrel=1
 pkgdesc="A QtQuick based components set (Android, $_pkg_arch)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=('cmake' 'android-ndk' 'android-sdk' 'extra-cmake-modules')
 conflicts=("android-$_pkgname-$_android_arch")
 replaces=("android-$_pkgname-$_android_arch")
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/$_pkgname-$pkgver.tar.xz"{,.sig})
-sha256sums=('b3cc36bddb5e52617075961b2cbaecbb94492523bcc6801a3ad29a35c43bd912'
+sha256sums=('8cf742d8f695c5ff6c7bcb5da1baddb50f5f5a0e96e879d8243704c847cd1443'
             'SKIP')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 options=(!buildflags staticlibs !strip !emptydirs)
@@ -40,6 +40,7 @@ build() {
   cmake ../$_pkgname-$pkgver \
     -DCMAKE_SYSTEM_NAME=Android \
     -DCMAKE_SYSTEM_VERSION=$_android_platform \
+    -DANDROID_ABI=$_android_arch \
     -DCMAKE_ANDROID_ARCH_ABI=$_android_arch \
     -DCMAKE_ANDROID_NDK=/opt/android-ndk \
     -DCMAKE_ANDROID_SDK=/opt/android-sdk \

--- a/kirigami2/android-armv7a-eabi/PKGBUILD
+++ b/kirigami2/android-armv7a-eabi/PKGBUILD
@@ -12,7 +12,7 @@ _android_platform=21
 _prefix=/opt/android-libs/$_pkg_arch
 
 pkgname=android-$_pkg_arch-$_pkgname
-pkgver=5.62.0
+pkgver=5.69.0
 pkgrel=1
 pkgdesc="A QtQuick based components set (Android, $_pkg_arch)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=('cmake' 'android-ndk' 'android-sdk' 'extra-cmake-modules')
 conflicts=("android-$_pkgname-$_android_arch")
 replaces=("android-$_pkgname-$_android_arch")
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/$_pkgname-$pkgver.tar.xz"{,.sig})
-sha256sums=('b3cc36bddb5e52617075961b2cbaecbb94492523bcc6801a3ad29a35c43bd912'
+sha256sums=('8cf742d8f695c5ff6c7bcb5da1baddb50f5f5a0e96e879d8243704c847cd1443'
             'SKIP')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 options=(!buildflags staticlibs !strip !emptydirs)
@@ -40,6 +40,7 @@ build() {
   cmake ../$_pkgname-$pkgver \
     -DCMAKE_SYSTEM_NAME=Android \
     -DCMAKE_SYSTEM_VERSION=$_android_platform \
+    -DANDROID_ABI=$_android_arch \
     -DCMAKE_ANDROID_ARCH_ABI=$_android_arch \
     -DCMAKE_ANDROID_NDK=/opt/android-ndk \
     -DCMAKE_ANDROID_SDK=/opt/android-sdk \

--- a/kirigami2/android-x86-64/PKGBUILD
+++ b/kirigami2/android-x86-64/PKGBUILD
@@ -12,7 +12,7 @@ _android_platform=22
 _prefix=/opt/android-libs/$_pkg_arch
 
 pkgname=android-$_pkg_arch-$_pkgname
-pkgver=5.62.0
+pkgver=5.69.0
 pkgrel=1
 pkgdesc="A QtQuick based components set (Android, $_pkg_arch)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=('cmake' 'android-ndk' 'android-sdk' 'extra-cmake-modules')
 conflicts=("android-$_pkgname-$_android_arch")
 replaces=("android-$_pkgname-$_android_arch")
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/$_pkgname-$pkgver.tar.xz"{,.sig})
-sha256sums=('b3cc36bddb5e52617075961b2cbaecbb94492523bcc6801a3ad29a35c43bd912'
+sha256sums=('8cf742d8f695c5ff6c7bcb5da1baddb50f5f5a0e96e879d8243704c847cd1443'
             'SKIP')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 options=(!buildflags staticlibs !strip !emptydirs)
@@ -40,6 +40,7 @@ build() {
   cmake ../$_pkgname-$pkgver \
     -DCMAKE_SYSTEM_NAME=Android \
     -DCMAKE_SYSTEM_VERSION=$_android_platform \
+    -DANDROID_ABI=$_android_arch \
     -DCMAKE_ANDROID_ARCH_ABI=$_android_arch \
     -DCMAKE_ANDROID_NDK=/opt/android-ndk \
     -DCMAKE_ANDROID_SDK=/opt/android-sdk \

--- a/kirigami2/android-x86/PKGBUILD
+++ b/kirigami2/android-x86/PKGBUILD
@@ -12,7 +12,7 @@ _android_platform=22
 _prefix=/opt/android-libs/$_pkg_arch
 
 pkgname=android-$_pkg_arch-$_pkgname
-pkgver=5.62.0
+pkgver=5.69.0
 pkgrel=1
 pkgdesc="A QtQuick based components set (Android, $_pkg_arch)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=('cmake' 'android-ndk' 'android-sdk' 'extra-cmake-modules')
 conflicts=("android-$_pkgname-$_android_arch")
 replaces=("android-$_pkgname-$_android_arch")
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/$_pkgname-$pkgver.tar.xz"{,.sig})
-sha256sums=('b3cc36bddb5e52617075961b2cbaecbb94492523bcc6801a3ad29a35c43bd912'
+sha256sums=('8cf742d8f695c5ff6c7bcb5da1baddb50f5f5a0e96e879d8243704c847cd1443'
             'SKIP')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 options=(!buildflags staticlibs !strip !emptydirs)
@@ -40,6 +40,7 @@ build() {
   cmake ../$_pkgname-$pkgver \
     -DCMAKE_SYSTEM_NAME=Android \
     -DCMAKE_SYSTEM_VERSION=$_android_platform \
+    -DANDROID_ABI=$_android_arch \
     -DCMAKE_ANDROID_ARCH_ABI=$_android_arch \
     -DCMAKE_ANDROID_NDK=/opt/android-ndk \
     -DCMAKE_ANDROID_SDK=/opt/android-sdk \

--- a/kirigami2/default/PKGBUILD
+++ b/kirigami2/default/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Antonio Rojas <arojas@archlinux.org>
 
 pkgname=kirigami2
-pkgver=5.47.0
+pkgver=5.69.0
 pkgrel=2
 pkgdesc='A QtQuick based components set'
 arch=(x86_64)
@@ -12,7 +12,7 @@ groups=(kf5)
 depends=(qt5-quickcontrols qt5-quickcontrols2 qt5-graphicaleffects)
 makedepends=(extra-cmake-modules qt5-tools qt5-svg kpackage doxygen)
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"{,.sig})
-sha256sums=('ed2dd9e3a56f4728aca40c74ab02d48f9dda8d140b20328c5b29825f5683aad5'
+sha256sums=('8cf742d8f695c5ff6c7bcb5da1baddb50f5f5a0e96e879d8243704c847cd1443'
             'SKIP')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 

--- a/kirigami2/mingw-w64/PKGBUILD
+++ b/kirigami2/mingw-w64/PKGBUILD
@@ -6,7 +6,7 @@
 
 _pkgname=kirigami2
 pkgname=mingw-w64-$_pkgname
-pkgver=5.60.0
+pkgver=5.69.0
 pkgrel=1
 pkgdesc="A QtQuick based components set (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ license=(LGPL)
 depends=(mingw-w64-crt mingw-w64-qt5-quickcontrols mingw-w64-qt5-quickcontrols2 mingw-w64-qt5-graphicaleffects)
 makedepends=(mingw-w64-gcc mingw-w64-cmake mingw-w64-extra-cmake-modules mingw-w64-qt5-tools mingw-w64-qt5-svg kpackage)
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/$_pkgname-$pkgver.tar.xz"{,.sig})
-sha256sums=('f016481d393041513dda11345e9ee84723587fa4be9f17391ed1a5868477e153'
+sha256sums=('8cf742d8f695c5ff6c7bcb5da1baddb50f5f5a0e96e879d8243704c847cd1443'
             'SKIP')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 options=(!buildflags staticlibs !strip !emptydirs)


### PR DESCRIPTION
Updates kirigami2 to 5.69.0 and also fixes a build error where it would always try to find the armv7a libraries. Only default, mingw-w64 and android-aarch64 are actually tested, but all should work fine.
Updating it also requires updating extra-cmake-modules.