### PR TITLE
Fix incorrect checksums for qt5-tools packages

### DIFF
--- a/qt5-tools/mingw-w64-static/PKGBUILD
+++ b/qt5-tools/mingw-w64-static/PKGBUILD
@@ -24,7 +24,7 @@
 _qt_module=qttools
 pkgname=mingw-w64-qt5-tools-static
 pkgver=5.15.1
-pkgrel=2
+pkgrel=1
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (Development Tools, QtHelp; mingw-w64)"
 depends=('mingw-w64-qt5-declarative-static')

--- a/qt5-tools/mingw-w64-static/PKGBUILD
+++ b/qt5-tools/mingw-w64-static/PKGBUILD
@@ -24,7 +24,7 @@
 _qt_module=qttools
 pkgname=mingw-w64-qt5-tools-static
 pkgver=5.15.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (Development Tools, QtHelp; mingw-w64)"
 depends=('mingw-w64-qt5-declarative-static')
@@ -37,7 +37,7 @@ _pkgfqn="${_qt_module}-everywhere-src-${pkgver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${pkgver}/submodules/${_pkgfqn}.tar.xz"
         '0001-Fix-linguist-macro.patch')
 sha256sums=('c98ee5f0f980bf68cbf0c94d62434816a92441733de50bd9adbe9b9055f03498'
-            'ca4cdea138d38a8f55a20f4821d35138035115dd1c61ae1b28156d90aa75b38a')
+            '23243c0326d63474a293cec35cb0b64795e46b90ddc631d240b128274c030421')
 
 _architectures='i686-w64-mingw32 x86_64-w64-mingw32'
 

--- a/qt5-tools/mingw-w64/PKGBUILD
+++ b/qt5-tools/mingw-w64/PKGBUILD
@@ -24,7 +24,7 @@
 _qt_module=qttools
 pkgname=mingw-w64-qt5-tools
 pkgver=5.15.1
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 pkgdesc="A cross-platform application and UI framework (Development Tools, QtHelp; mingw-w64)"
 depends=('mingw-w64-qt5-declarative')
@@ -37,7 +37,7 @@ _pkgfqn="${_qt_module}-everywhere-src-${pkgver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${pkgver}/submodules/${_pkgfqn}.tar.xz"
         '0001-Fix-linguist-macro.patch')
 sha256sums=('c98ee5f0f980bf68cbf0c94d62434816a92441733de50bd9adbe9b9055f03498'
-            'ca4cdea138d38a8f55a20f4821d35138035115dd1c61ae1b28156d90aa75b38a')
+            '23243c0326d63474a293cec35cb0b64795e46b90ddc631d240b128274c030421')
 
 _architectures='i686-w64-mingw32 x86_64-w64-mingw32'
 

--- a/qt5-tools/mingw-w64/PKGBUILD
+++ b/qt5-tools/mingw-w64/PKGBUILD
@@ -24,7 +24,7 @@
 _qt_module=qttools
 pkgname=mingw-w64-qt5-tools
 pkgver=5.15.1
-pkgrel=2
+pkgrel=1
 arch=('i686' 'x86_64')
 pkgdesc="A cross-platform application and UI framework (Development Tools, QtHelp; mingw-w64)"
 depends=('mingw-w64-qt5-declarative')


### PR DESCRIPTION
The `mingw-w64-qt5-tools` and `mingw-w64-qt5-tools-static` packages have incorrect checksums for the `0001-Fix-linguist-macro.patch` file, making them not build. This updates to the correct checksums.