### PR TITLE
mingw-w64-qt6-base: depend on native package

### DIFF
--- a/qt6-base/mingw-w64/PKGBUILD
+++ b/qt6-base/mingw-w64/PKGBUILD
@@ -13,14 +13,14 @@
 pkgname=mingw-w64-qt6-base
 _qtver=6.0.0-beta2
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 url='https://www.qt.io'
 license=(GPL3 LGPL3 FDL custom)
 pkgdesc='A cross-platform application and UI framework (mingw-w64)'
 depends=('mingw-w64-crt' 'mingw-w64-zlib' 'mingw-w64-libjpeg-turbo' 'mingw-w64-sqlite'
          'mingw-w64-libpng' 'mingw-w64-openssl' 'mingw-w64-dbus' 'mingw-w64-harfbuzz'
-         'mingw-w64-brotli' 'mingw-w64-pcre2' 'mingw-w64-zstd')
+         'mingw-w64-brotli' 'mingw-w64-pcre2' 'mingw-w64-zstd' 'qt6-base')
 makedepends=('mingw-w64-cmake' 'mingw-w64-postgresql' 'mingw-w64-mariadb-connector-c'
              'mingw-w64-vulkan-headers' 'mingw-w64-vulkan-icd-loader' 'mingw-w64-pkg-config'
              'qt6-base' 'ninja')


### PR DESCRIPTION
for qmake