### PR TITLE
mingw-w64-cmake Drop vulkan overrides

### DIFF
--- a/cmake/mingw-w64/toolchain-mingw.cmake
+++ b/cmake/mingw-w64/toolchain-mingw.cmake
@@ -35,7 +35,5 @@ set (CMAKE_RANLIB:FILEPATH @TRIPLE@-ranlib)
 set(QT_HOST_PATH "/usr" CACHE PATH "host path for Qt")
 
 # workaround limitations in CMake's find modules
-set(Vulkan_LIBRARY "/usr/@TRIPLE@/lib/libvulkan.dll.a" CACHE FILEPATH "Vulkan IDC library")
-set(Vulkan_INCLUDE_DIR "/usr/@TRIPLE@/include" CACHE PATH "Vulkan headers directory")
 set(MySQL_LIBRARIES "/usr/@TRIPLE@/lib/libmariadb.dll.a" CACHE INTERNAL "MariaDB client library")
 set(MySQL_INCLUDE_DIRS "/usr/@TRIPLE@/include/mariadb" CACHE INTERNAL "MariaDB client library")


### PR DESCRIPTION
sorry, but I dont see what that is supposed to fix, the actual library name is /usr/i686-w64-mingw32/lib/libvulkan-1.dll.a and is correctly fond by the default findvulkan.cmake