### PR TITLE
Update mingw extra-cmake-modules to 5.76.0

### DIFF
--- a/extra-cmake-modules/mingw-w64/PKGBUILD
+++ b/extra-cmake-modules/mingw-w64/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=mingw-w64-extra-cmake-modules
-pkgver=5.69.0
+pkgver=5.76.0
 pkgrel=1
 arch=(any)
 pkgdesc="Extra modules and scripts for CMake (mingw-w64)"
@@ -11,7 +11,7 @@ url="https://community.kde.org/Frameworks"
 source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/extra-cmake-modules-${pkgver}.tar.xz"{,.sig}
 "set-AUTOSTATICPLUGINS.patch"
 "05aa27dc0e14dab407379a4d22f895e9eff13cc0.patch")
-sha256sums=('dacc8e0be8605b6c609ea35bda2d87bf06e1d228bcbf8957b0f0230c4a888359'
+sha256sums=('4845e9e0a43ba15158c0cfdc7ab594e7d02692fab9083201715270a096704a32'
             'SKIP'
             '30bdcedab402c69ea0db3460f5a23cbd226a5cd1e12b13926b8a65df773e14a0'
             '7e44cf56a8274c8166eaf02e60c2d34e5048992a7e3c8309b998b762a394e909')


### PR DESCRIPTION
Have updated all mingw KF5 packages in AUR to 5.76.0.
Can you update it there or orphan it and I'll do it.

cheers

BTW Have made some build scripts to create arch packages on openSUSE build system.
eg. https://build.opensuse.org/package/show/home:maxrd2/pocketsphinx
What do you think if we create repo and put all mingw PKGBUILDs in one repo there. You are building all mingw-qt5 packages here, I do the same here https://github.com/maxrd2/arch-repo/releases.
That way we could share effort and all packages would be built in clean chroot on OBS.