### PR TITLE
(android-*-openssl) Added patch for android build configuration

### DIFF
--- a/openssl/android-aarch64/15-android_conf.patch
+++ b/openssl/android-aarch64/15-android_conf.patch
@@ -1,0 +1,217 @@
+diff --git a/Configurations/15-android.conf b/Configurations/15-android.conf
+index 4616394f8c..f3075e4b79 100644
+--- a/Configurations/15-android.conf
++++ b/Configurations/15-android.conf
+@@ -1,6 +1,6 @@
+ #### Android...
+ #
+-# See NOTES.ANDROID for details, and don't miss platform-specific
++# See NOTES-Android.md for details, and don't miss platform-specific
+ # comments below...
+ 
+ {
+@@ -24,23 +24,23 @@
+ 
+             my $ndk_var;
+             my $ndk;
+-            foreach (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
++            foreach (qw(ANDROID_NDK_ROOT ANDROID_NDK)) {
+                 $ndk_var = $_;
+                 $ndk = $ENV{$ndk_var};
+                 last if defined $ndk;
+             }
+-            die "\$ANDROID_NDK_HOME is not defined"  if (!$ndk);
+-            if (!-d "$ndk/platforms" && !-f "$ndk/AndroidVersion.txt") {
+-                # $ndk/platforms is traditional "all-inclusive" NDK, while
+-                # $ndk/AndroidVersion.txt is so-called standalone toolchain
+-                # tailored for specific target down to API level.
+-                die "\$ANDROID_NDK_HOME=$ndk is invalid";
++            die "\$ANDROID_NDK_ROOT is not defined"  if (!$ndk);
++            my $is_standalone_toolchain = -f "$ndk/AndroidVersion.txt";
++            my $ndk_src_props = "$ndk/source.properties";
++            my $is_ndk = -f $ndk_src_props;
++            if ($is_ndk == $is_standalone_toolchain) {
++                die "\$ANDROID_NDK_ROOT=$ndk is invalid";
+             }
+             $ndk = canonpath($ndk);
+ 
+             my $ndkver = undef;
+ 
+-            if (open my $fh, "<$ndk/source.properties") {
++            if (open my $fh, "<$ndk_src_props") {
+                 local $_;
+                 while(<$fh>) {
+                     if (m|Pkg\.Revision\s*=\s*([0-9]+)|) {
+@@ -59,7 +59,7 @@
+             if ($sysroot = $ENV{CROSS_SYSROOT}) {
+                 $sysroot =~ m|/android-([0-9]+)/arch-(\w+)/?$|;
+                 ($api, $arch) = ($1, $2);
+-            } elsif (-f "$ndk/AndroidVersion.txt") {
++            } elsif ($is_standalone_toolchain) {
+                 $sysroot = "$ndk/sysroot";
+             } else {
+                 $api = "*";
+@@ -72,17 +72,31 @@
+                     }
+                 }
+ 
+-                # list available platforms (numerically)
+-                my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
+-                                       $b =~ m/-([0-9]+)$/; $aa <=> $1;
+-                                     } glob("$ndk/platforms/android-$api");
+-                die "no $ndk/platforms/android-$api" if ($#platforms < 0);
++                if (-d "$ndk/platforms") {
++                    # list available platforms (numerically)
++                    my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
++                                           $b =~ m/-([0-9]+)$/; $aa <=> $1;
++                                         } glob("$ndk/platforms/android-$api");
++                    die "no $ndk/platforms/android-$api" if ($#platforms < 0);
+ 
+-                $sysroot = "@platforms[$#platforms]/arch-$arch";
+-                $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
+-                $api = $1;
++                    $sysroot = "@platforms[$#platforms]/arch-$arch";
++                    $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
++                    $api = $1;
++                } elsif ($api eq "*") {
++                    # r22 Removed platforms dir, use this JSON file
++                    my $path = "$ndk/meta/platforms.json";
++                    open my $fh, $path or die "Could not open '$path' $!";
++                    while (<$fh>) {
++                        if (/"max": (\d+),/) {
++                            $api = $1;
++                            last;
++                        }
++                    }
++                    close $fh;
++                }
++                die "Could not get default API Level" if ($api eq "*");
+             }
+-            die "no sysroot=$sysroot"   if (!-d $sysroot);
++            die "no sysroot=$sysroot" if (length $sysroot && !-d $sysroot);
+ 
+             my $triarch = $triplet{$arch};
+             my $cflags;
+@@ -95,17 +109,21 @@
+                 my $arm = $ndkver > 16 ? "armv7a" : "armv5te";
+                 (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
+                 (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
+-                $cflags .= " -target $tridefault "
+-                        .  "-gcc-toolchain \$($ndk_var)/toolchains"
+-                        .  "/$tritools-4.9/prebuilt/$host";
+-                $user{CC} = "clang" if ($user{CC} !~ m|clang|);
++                if (length $sysroot) {
++                    $cflags .= " -target $tridefault "
++                            .  "-gcc-toolchain \$($ndk_var)/toolchains"
++                            .  "/$tritools-4.9/prebuilt/$host";
++                    $user{CC} = "clang" if ($user{CC} !~ m|clang|);
++                } else {
++                    $user{CC} = "$tridefault$api-clang";
++                }
+                 $user{CROSS_COMPILE} = undef;
+                 if (which("llvm-ar") =~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
+                     $user{AR} = "llvm-ar";
+                     $user{ARFLAGS} = [ "rs" ];
+                     $user{RANLIB} = ":";
+                 }
+-            } elsif (-f "$ndk/AndroidVersion.txt") {    #"standalone toolchain"
++            } elsif ($is_standalone_toolchain) {
+                 my $cc = $user{CC} // "clang";
+                 # One can probably argue that both clang and gcc should be
+                 # probed, but support for "standalone toolchain" was added
+@@ -127,19 +145,21 @@
+                 $user{CROSS_COMPILE} = "$triarch-";
+             }
+ 
+-            if (!-d "$sysroot/usr/include") {
+-                my $incroot = "$ndk/sysroot/usr/include";
+-                die "no $incroot"          if (!-d $incroot);
+-                die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
+-                $incroot =~ s|^$ndk/||;
+-                $cppflags  = "-D__ANDROID_API__=$api";
+-                $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
+-                $cppflags .= " -isystem \$($ndk_var)/$incroot";
++            if (length $sysroot) {
++                if (!-d "$sysroot/usr/include") {
++                    my $incroot = "$ndk/sysroot/usr/include";
++                    die "no $incroot"          if (!-d $incroot);
++                    die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
++                    $incroot =~ s|^$ndk/||;
++                    $cppflags  = "-D__ANDROID_API__=$api";
++                    $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
++                    $cppflags .= " -isystem \$($ndk_var)/$incroot";
++                }
++                $sysroot =~ s|^$ndk/||;
++                $sysroot = " --sysroot=\$($ndk_var)/$sysroot";
+             }
+-
+-            $sysroot =~ s|^$ndk/||;
+             $android_ndk = {
+-                cflags   => "$cflags --sysroot=\$($ndk_var)/$sysroot",
++                cflags   => $cflags . $sysroot,
+                 cppflags => $cppflags,
+                 bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
+                                             : "BN_LLONG",
+@@ -168,7 +188,8 @@ my %targets = (
+         cppflags         => add(sub { android_ndk()->{cppflags} }),
+         cxxflags         => add(sub { android_ndk()->{cflags} }),
+         bn_ops           => sub { android_ndk()->{bn_ops} },
+-        bin_cflags       => "-pie",
++        bin_cflags       => "-fPIE",
++        bin_lflags       => "-pie",
+         enable           => [ ],
+     },
+     "android-arm" => {
+@@ -199,18 +220,22 @@ my %targets = (
+         # -march and/or -mfloat-abi flags. NDK defaults to armv5te.
+         # Newer NDK versions reportedly require additional -latomic.
+         #
+-        inherit_from     => [ "android", asm("armv4_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'armv4',
++        perlasm_scheme   => "void",
+     },
+     "android-arm64" => {
+-        inherit_from     => [ "android", asm("aarch64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'aarch64',
+         perlasm_scheme   => "linux64",
+     },
+ 
+     "android-mips" => {
+-        inherit_from     => [ "android", asm("mips32_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'mips32',
+         perlasm_scheme   => "o32",
+     },
+     "android-mips64" => {
+@@ -223,20 +248,23 @@ my %targets = (
+         # with previous MIPS ISA versions, in sense that unlike
+         # prior versions original MIPS binary code will fail.
+         #
+-        inherit_from     => [ "android", asm("mips64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'mips64',
+         perlasm_scheme   => "64",
+     },
+ 
+     "android-x86" => {
+-        inherit_from     => [ "android", asm("x86_asm") ],
++        inherit_from     => [ "android" ],
+         CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
+         bn_ops           => add("RC4_INT"),
++        asm_arch         => 'x86',
+         perlasm_scheme   => "android",
+     },
+     "android-x86_64" => {
+-        inherit_from     => [ "android", asm("x86_64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_INT"),
++        asm_arch         => 'x86_64',
+         perlasm_scheme   => "elf",
+     },
+ 

--- a/openssl/android-aarch64/PKGBUILD
+++ b/openssl/android-aarch64/PKGBUILD
@@ -6,11 +6,12 @@ _android_arch=arm64-v8a
 _android_platform_arch=arch-arm64
 _pkgname=openssl
 _ver=1.1.1i
+_patchname=15-android_conf
 
 pkgname=android-$_pkg_arch-$_pkgname
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (Android, $_pkg_arch)"
 arch=('any')
 url='https://www.openssl.org'
@@ -20,16 +21,23 @@ depends=('android-sdk' 'android-ndk')
 makedepends=('android-environment' 'android-sdk-build-tools')
 conflicts=("android-$_pkgname-$_android_arch")
 replaces=("android-$_pkgname-$_android_arch")
-source=("https://www.openssl.org/source/${_pkgname}-${_ver}.tar.gz"{,.asc})
+source=("https://www.openssl.org/source/${_pkgname}-${_ver}.tar.gz"{,.asc}
+       "${_patchname}.patch")
 sha256sums=('e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242'
-            'SKIP')
+            'SKIP'
+            '8ed3b78e8d6e5766595ae5ad6503cf0d21de4300d90aae556c7786f07ed9fdfb')
 validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491'
               '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C')
 
 build() {
-  cd "$srcdir/$_pkgname-$_ver"
+  cd "${srcdir}/${_pkgname}-${_ver}"
   source android-env ${_pkg_arch}
-  export PATH="$ANDROID_TOOLCHAIN/bin:$PATH"
+  export PATH="${ANDROID_TOOLCHAIN}/bin:${PATH}"
+
+  # Configure configuration script for android that shipped with openssl
+  # 1.1.1i does not account for the removal of the $ndk/platforms directory in
+  # android-ndk r22.
+  patch -Np1 < "${srcdir}/${_patchname}.patch"
 
   # don't use -mandroid flag (Clang as provided by the NDK does not like it)
   sed -i -e 's/-mandroid//' Configurations/15-android.conf
@@ -41,7 +49,7 @@ build() {
     -Wl,--no-allow-shlib-undefined \
     -Wl,--no-undefined \
     no-stdio \
-    no-ui \
+    no-ui-console \
     threads \
     shared \
     android-${_android_platform_arch##arch-}

--- a/openssl/android-armv7a-eabi/15-android_conf.patch
+++ b/openssl/android-armv7a-eabi/15-android_conf.patch
@@ -1,0 +1,217 @@
+diff --git a/Configurations/15-android.conf b/Configurations/15-android.conf
+index 4616394f8c..f3075e4b79 100644
+--- a/Configurations/15-android.conf
++++ b/Configurations/15-android.conf
+@@ -1,6 +1,6 @@
+ #### Android...
+ #
+-# See NOTES.ANDROID for details, and don't miss platform-specific
++# See NOTES-Android.md for details, and don't miss platform-specific
+ # comments below...
+ 
+ {
+@@ -24,23 +24,23 @@
+ 
+             my $ndk_var;
+             my $ndk;
+-            foreach (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
++            foreach (qw(ANDROID_NDK_ROOT ANDROID_NDK)) {
+                 $ndk_var = $_;
+                 $ndk = $ENV{$ndk_var};
+                 last if defined $ndk;
+             }
+-            die "\$ANDROID_NDK_HOME is not defined"  if (!$ndk);
+-            if (!-d "$ndk/platforms" && !-f "$ndk/AndroidVersion.txt") {
+-                # $ndk/platforms is traditional "all-inclusive" NDK, while
+-                # $ndk/AndroidVersion.txt is so-called standalone toolchain
+-                # tailored for specific target down to API level.
+-                die "\$ANDROID_NDK_HOME=$ndk is invalid";
++            die "\$ANDROID_NDK_ROOT is not defined"  if (!$ndk);
++            my $is_standalone_toolchain = -f "$ndk/AndroidVersion.txt";
++            my $ndk_src_props = "$ndk/source.properties";
++            my $is_ndk = -f $ndk_src_props;
++            if ($is_ndk == $is_standalone_toolchain) {
++                die "\$ANDROID_NDK_ROOT=$ndk is invalid";
+             }
+             $ndk = canonpath($ndk);
+ 
+             my $ndkver = undef;
+ 
+-            if (open my $fh, "<$ndk/source.properties") {
++            if (open my $fh, "<$ndk_src_props") {
+                 local $_;
+                 while(<$fh>) {
+                     if (m|Pkg\.Revision\s*=\s*([0-9]+)|) {
+@@ -59,7 +59,7 @@
+             if ($sysroot = $ENV{CROSS_SYSROOT}) {
+                 $sysroot =~ m|/android-([0-9]+)/arch-(\w+)/?$|;
+                 ($api, $arch) = ($1, $2);
+-            } elsif (-f "$ndk/AndroidVersion.txt") {
++            } elsif ($is_standalone_toolchain) {
+                 $sysroot = "$ndk/sysroot";
+             } else {
+                 $api = "*";
+@@ -72,17 +72,31 @@
+                     }
+                 }
+ 
+-                # list available platforms (numerically)
+-                my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
+-                                       $b =~ m/-([0-9]+)$/; $aa <=> $1;
+-                                     } glob("$ndk/platforms/android-$api");
+-                die "no $ndk/platforms/android-$api" if ($#platforms < 0);
++                if (-d "$ndk/platforms") {
++                    # list available platforms (numerically)
++                    my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
++                                           $b =~ m/-([0-9]+)$/; $aa <=> $1;
++                                         } glob("$ndk/platforms/android-$api");
++                    die "no $ndk/platforms/android-$api" if ($#platforms < 0);
+ 
+-                $sysroot = "@platforms[$#platforms]/arch-$arch";
+-                $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
+-                $api = $1;
++                    $sysroot = "@platforms[$#platforms]/arch-$arch";
++                    $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
++                    $api = $1;
++                } elsif ($api eq "*") {
++                    # r22 Removed platforms dir, use this JSON file
++                    my $path = "$ndk/meta/platforms.json";
++                    open my $fh, $path or die "Could not open '$path' $!";
++                    while (<$fh>) {
++                        if (/"max": (\d+),/) {
++                            $api = $1;
++                            last;
++                        }
++                    }
++                    close $fh;
++                }
++                die "Could not get default API Level" if ($api eq "*");
+             }
+-            die "no sysroot=$sysroot"   if (!-d $sysroot);
++            die "no sysroot=$sysroot" if (length $sysroot && !-d $sysroot);
+ 
+             my $triarch = $triplet{$arch};
+             my $cflags;
+@@ -95,17 +109,21 @@
+                 my $arm = $ndkver > 16 ? "armv7a" : "armv5te";
+                 (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
+                 (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
+-                $cflags .= " -target $tridefault "
+-                        .  "-gcc-toolchain \$($ndk_var)/toolchains"
+-                        .  "/$tritools-4.9/prebuilt/$host";
+-                $user{CC} = "clang" if ($user{CC} !~ m|clang|);
++                if (length $sysroot) {
++                    $cflags .= " -target $tridefault "
++                            .  "-gcc-toolchain \$($ndk_var)/toolchains"
++                            .  "/$tritools-4.9/prebuilt/$host";
++                    $user{CC} = "clang" if ($user{CC} !~ m|clang|);
++                } else {
++                    $user{CC} = "$tridefault$api-clang";
++                }
+                 $user{CROSS_COMPILE} = undef;
+                 if (which("llvm-ar") =~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
+                     $user{AR} = "llvm-ar";
+                     $user{ARFLAGS} = [ "rs" ];
+                     $user{RANLIB} = ":";
+                 }
+-            } elsif (-f "$ndk/AndroidVersion.txt") {    #"standalone toolchain"
++            } elsif ($is_standalone_toolchain) {
+                 my $cc = $user{CC} // "clang";
+                 # One can probably argue that both clang and gcc should be
+                 # probed, but support for "standalone toolchain" was added
+@@ -127,19 +145,21 @@
+                 $user{CROSS_COMPILE} = "$triarch-";
+             }
+ 
+-            if (!-d "$sysroot/usr/include") {
+-                my $incroot = "$ndk/sysroot/usr/include";
+-                die "no $incroot"          if (!-d $incroot);
+-                die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
+-                $incroot =~ s|^$ndk/||;
+-                $cppflags  = "-D__ANDROID_API__=$api";
+-                $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
+-                $cppflags .= " -isystem \$($ndk_var)/$incroot";
++            if (length $sysroot) {
++                if (!-d "$sysroot/usr/include") {
++                    my $incroot = "$ndk/sysroot/usr/include";
++                    die "no $incroot"          if (!-d $incroot);
++                    die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
++                    $incroot =~ s|^$ndk/||;
++                    $cppflags  = "-D__ANDROID_API__=$api";
++                    $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
++                    $cppflags .= " -isystem \$($ndk_var)/$incroot";
++                }
++                $sysroot =~ s|^$ndk/||;
++                $sysroot = " --sysroot=\$($ndk_var)/$sysroot";
+             }
+-
+-            $sysroot =~ s|^$ndk/||;
+             $android_ndk = {
+-                cflags   => "$cflags --sysroot=\$($ndk_var)/$sysroot",
++                cflags   => $cflags . $sysroot,
+                 cppflags => $cppflags,
+                 bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
+                                             : "BN_LLONG",
+@@ -168,7 +188,8 @@ my %targets = (
+         cppflags         => add(sub { android_ndk()->{cppflags} }),
+         cxxflags         => add(sub { android_ndk()->{cflags} }),
+         bn_ops           => sub { android_ndk()->{bn_ops} },
+-        bin_cflags       => "-pie",
++        bin_cflags       => "-fPIE",
++        bin_lflags       => "-pie",
+         enable           => [ ],
+     },
+     "android-arm" => {
+@@ -199,18 +220,22 @@ my %targets = (
+         # -march and/or -mfloat-abi flags. NDK defaults to armv5te.
+         # Newer NDK versions reportedly require additional -latomic.
+         #
+-        inherit_from     => [ "android", asm("armv4_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'armv4',
++        perlasm_scheme   => "void",
+     },
+     "android-arm64" => {
+-        inherit_from     => [ "android", asm("aarch64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'aarch64',
+         perlasm_scheme   => "linux64",
+     },
+ 
+     "android-mips" => {
+-        inherit_from     => [ "android", asm("mips32_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'mips32',
+         perlasm_scheme   => "o32",
+     },
+     "android-mips64" => {
+@@ -223,20 +248,23 @@ my %targets = (
+         # with previous MIPS ISA versions, in sense that unlike
+         # prior versions original MIPS binary code will fail.
+         #
+-        inherit_from     => [ "android", asm("mips64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'mips64',
+         perlasm_scheme   => "64",
+     },
+ 
+     "android-x86" => {
+-        inherit_from     => [ "android", asm("x86_asm") ],
++        inherit_from     => [ "android" ],
+         CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
+         bn_ops           => add("RC4_INT"),
++        asm_arch         => 'x86',
+         perlasm_scheme   => "android",
+     },
+     "android-x86_64" => {
+-        inherit_from     => [ "android", asm("x86_64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_INT"),
++        asm_arch         => 'x86_64',
+         perlasm_scheme   => "elf",
+     },
+ 

--- a/openssl/android-armv7a-eabi/PKGBUILD
+++ b/openssl/android-armv7a-eabi/PKGBUILD
@@ -6,11 +6,12 @@ _android_arch=armeabi-v7a
 _android_platform_arch=arch-arm
 _pkgname=openssl
 _ver=1.1.1i
+_patchname=15-android_conf
 
 pkgname=android-$_pkg_arch-$_pkgname
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (Android, $_pkg_arch)"
 arch=('any')
 url='https://www.openssl.org'
@@ -20,16 +21,23 @@ depends=('android-sdk' 'android-ndk')
 makedepends=('android-environment' 'android-sdk-build-tools')
 conflicts=("android-$_pkgname-$_android_arch")
 replaces=("android-$_pkgname-$_android_arch")
-source=("https://www.openssl.org/source/${_pkgname}-${_ver}.tar.gz"{,.asc})
+source=("https://www.openssl.org/source/${_pkgname}-${_ver}.tar.gz"{,.asc}
+       "${_patchname}.patch")
 sha256sums=('e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242'
-            'SKIP')
+            'SKIP'
+            '8ed3b78e8d6e5766595ae5ad6503cf0d21de4300d90aae556c7786f07ed9fdfb')
 validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491'
               '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C')
 
 build() {
-  cd "$srcdir/$_pkgname-$_ver"
+  cd "${srcdir}/${_pkgname}-${_ver}"
   source android-env ${_pkg_arch}
-  export PATH="$ANDROID_TOOLCHAIN/bin:$PATH"
+  export PATH="${ANDROID_TOOLCHAIN}/bin:${PATH}"
+
+  # Configure configuration script for android that shipped with openssl
+  # 1.1.1i does not account for the removal of the $ndk/platforms directory in
+  # android-ndk r22.
+  patch -Np1 < "${srcdir}/${_patchname}.patch"
 
   # don't use -mandroid flag (Clang as provided by the NDK does not like it)
   sed -i -e 's/-mandroid//' Configurations/15-android.conf
@@ -41,7 +49,7 @@ build() {
     -Wl,--no-allow-shlib-undefined \
     -Wl,--no-undefined \
     no-stdio \
-    no-ui \
+    no-ui-console \
     threads \
     shared \
     android-${_android_platform_arch##arch-}

--- a/openssl/android-x86-64/15-android_conf.patch
+++ b/openssl/android-x86-64/15-android_conf.patch
@@ -1,0 +1,217 @@
+diff --git a/Configurations/15-android.conf b/Configurations/15-android.conf
+index 4616394f8c..f3075e4b79 100644
+--- a/Configurations/15-android.conf
++++ b/Configurations/15-android.conf
+@@ -1,6 +1,6 @@
+ #### Android...
+ #
+-# See NOTES.ANDROID for details, and don't miss platform-specific
++# See NOTES-Android.md for details, and don't miss platform-specific
+ # comments below...
+ 
+ {
+@@ -24,23 +24,23 @@
+ 
+             my $ndk_var;
+             my $ndk;
+-            foreach (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
++            foreach (qw(ANDROID_NDK_ROOT ANDROID_NDK)) {
+                 $ndk_var = $_;
+                 $ndk = $ENV{$ndk_var};
+                 last if defined $ndk;
+             }
+-            die "\$ANDROID_NDK_HOME is not defined"  if (!$ndk);
+-            if (!-d "$ndk/platforms" && !-f "$ndk/AndroidVersion.txt") {
+-                # $ndk/platforms is traditional "all-inclusive" NDK, while
+-                # $ndk/AndroidVersion.txt is so-called standalone toolchain
+-                # tailored for specific target down to API level.
+-                die "\$ANDROID_NDK_HOME=$ndk is invalid";
++            die "\$ANDROID_NDK_ROOT is not defined"  if (!$ndk);
++            my $is_standalone_toolchain = -f "$ndk/AndroidVersion.txt";
++            my $ndk_src_props = "$ndk/source.properties";
++            my $is_ndk = -f $ndk_src_props;
++            if ($is_ndk == $is_standalone_toolchain) {
++                die "\$ANDROID_NDK_ROOT=$ndk is invalid";
+             }
+             $ndk = canonpath($ndk);
+ 
+             my $ndkver = undef;
+ 
+-            if (open my $fh, "<$ndk/source.properties") {
++            if (open my $fh, "<$ndk_src_props") {
+                 local $_;
+                 while(<$fh>) {
+                     if (m|Pkg\.Revision\s*=\s*([0-9]+)|) {
+@@ -59,7 +59,7 @@
+             if ($sysroot = $ENV{CROSS_SYSROOT}) {
+                 $sysroot =~ m|/android-([0-9]+)/arch-(\w+)/?$|;
+                 ($api, $arch) = ($1, $2);
+-            } elsif (-f "$ndk/AndroidVersion.txt") {
++            } elsif ($is_standalone_toolchain) {
+                 $sysroot = "$ndk/sysroot";
+             } else {
+                 $api = "*";
+@@ -72,17 +72,31 @@
+                     }
+                 }
+ 
+-                # list available platforms (numerically)
+-                my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
+-                                       $b =~ m/-([0-9]+)$/; $aa <=> $1;
+-                                     } glob("$ndk/platforms/android-$api");
+-                die "no $ndk/platforms/android-$api" if ($#platforms < 0);
++                if (-d "$ndk/platforms") {
++                    # list available platforms (numerically)
++                    my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
++                                           $b =~ m/-([0-9]+)$/; $aa <=> $1;
++                                         } glob("$ndk/platforms/android-$api");
++                    die "no $ndk/platforms/android-$api" if ($#platforms < 0);
+ 
+-                $sysroot = "@platforms[$#platforms]/arch-$arch";
+-                $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
+-                $api = $1;
++                    $sysroot = "@platforms[$#platforms]/arch-$arch";
++                    $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
++                    $api = $1;
++                } elsif ($api eq "*") {
++                    # r22 Removed platforms dir, use this JSON file
++                    my $path = "$ndk/meta/platforms.json";
++                    open my $fh, $path or die "Could not open '$path' $!";
++                    while (<$fh>) {
++                        if (/"max": (\d+),/) {
++                            $api = $1;
++                            last;
++                        }
++                    }
++                    close $fh;
++                }
++                die "Could not get default API Level" if ($api eq "*");
+             }
+-            die "no sysroot=$sysroot"   if (!-d $sysroot);
++            die "no sysroot=$sysroot" if (length $sysroot && !-d $sysroot);
+ 
+             my $triarch = $triplet{$arch};
+             my $cflags;
+@@ -95,17 +109,21 @@
+                 my $arm = $ndkver > 16 ? "armv7a" : "armv5te";
+                 (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
+                 (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
+-                $cflags .= " -target $tridefault "
+-                        .  "-gcc-toolchain \$($ndk_var)/toolchains"
+-                        .  "/$tritools-4.9/prebuilt/$host";
+-                $user{CC} = "clang" if ($user{CC} !~ m|clang|);
++                if (length $sysroot) {
++                    $cflags .= " -target $tridefault "
++                            .  "-gcc-toolchain \$($ndk_var)/toolchains"
++                            .  "/$tritools-4.9/prebuilt/$host";
++                    $user{CC} = "clang" if ($user{CC} !~ m|clang|);
++                } else {
++                    $user{CC} = "$tridefault$api-clang";
++                }
+                 $user{CROSS_COMPILE} = undef;
+                 if (which("llvm-ar") =~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
+                     $user{AR} = "llvm-ar";
+                     $user{ARFLAGS} = [ "rs" ];
+                     $user{RANLIB} = ":";
+                 }
+-            } elsif (-f "$ndk/AndroidVersion.txt") {    #"standalone toolchain"
++            } elsif ($is_standalone_toolchain) {
+                 my $cc = $user{CC} // "clang";
+                 # One can probably argue that both clang and gcc should be
+                 # probed, but support for "standalone toolchain" was added
+@@ -127,19 +145,21 @@
+                 $user{CROSS_COMPILE} = "$triarch-";
+             }
+ 
+-            if (!-d "$sysroot/usr/include") {
+-                my $incroot = "$ndk/sysroot/usr/include";
+-                die "no $incroot"          if (!-d $incroot);
+-                die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
+-                $incroot =~ s|^$ndk/||;
+-                $cppflags  = "-D__ANDROID_API__=$api";
+-                $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
+-                $cppflags .= " -isystem \$($ndk_var)/$incroot";
++            if (length $sysroot) {
++                if (!-d "$sysroot/usr/include") {
++                    my $incroot = "$ndk/sysroot/usr/include";
++                    die "no $incroot"          if (!-d $incroot);
++                    die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
++                    $incroot =~ s|^$ndk/||;
++                    $cppflags  = "-D__ANDROID_API__=$api";
++                    $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
++                    $cppflags .= " -isystem \$($ndk_var)/$incroot";
++                }
++                $sysroot =~ s|^$ndk/||;
++                $sysroot = " --sysroot=\$($ndk_var)/$sysroot";
+             }
+-
+-            $sysroot =~ s|^$ndk/||;
+             $android_ndk = {
+-                cflags   => "$cflags --sysroot=\$($ndk_var)/$sysroot",
++                cflags   => $cflags . $sysroot,
+                 cppflags => $cppflags,
+                 bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
+                                             : "BN_LLONG",
+@@ -168,7 +188,8 @@ my %targets = (
+         cppflags         => add(sub { android_ndk()->{cppflags} }),
+         cxxflags         => add(sub { android_ndk()->{cflags} }),
+         bn_ops           => sub { android_ndk()->{bn_ops} },
+-        bin_cflags       => "-pie",
++        bin_cflags       => "-fPIE",
++        bin_lflags       => "-pie",
+         enable           => [ ],
+     },
+     "android-arm" => {
+@@ -199,18 +220,22 @@ my %targets = (
+         # -march and/or -mfloat-abi flags. NDK defaults to armv5te.
+         # Newer NDK versions reportedly require additional -latomic.
+         #
+-        inherit_from     => [ "android", asm("armv4_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'armv4',
++        perlasm_scheme   => "void",
+     },
+     "android-arm64" => {
+-        inherit_from     => [ "android", asm("aarch64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'aarch64',
+         perlasm_scheme   => "linux64",
+     },
+ 
+     "android-mips" => {
+-        inherit_from     => [ "android", asm("mips32_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'mips32',
+         perlasm_scheme   => "o32",
+     },
+     "android-mips64" => {
+@@ -223,20 +248,23 @@ my %targets = (
+         # with previous MIPS ISA versions, in sense that unlike
+         # prior versions original MIPS binary code will fail.
+         #
+-        inherit_from     => [ "android", asm("mips64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'mips64',
+         perlasm_scheme   => "64",
+     },
+ 
+     "android-x86" => {
+-        inherit_from     => [ "android", asm("x86_asm") ],
++        inherit_from     => [ "android" ],
+         CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
+         bn_ops           => add("RC4_INT"),
++        asm_arch         => 'x86',
+         perlasm_scheme   => "android",
+     },
+     "android-x86_64" => {
+-        inherit_from     => [ "android", asm("x86_64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_INT"),
++        asm_arch         => 'x86_64',
+         perlasm_scheme   => "elf",
+     },
+ 

--- a/openssl/android-x86-64/PKGBUILD
+++ b/openssl/android-x86-64/PKGBUILD
@@ -6,11 +6,12 @@ _android_arch=x86_64
 _android_platform_arch=arch-x86_64
 _pkgname=openssl
 _ver=1.1.1i
+_patchname=15-android_conf
 
 pkgname=android-$_pkg_arch-$_pkgname
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (Android, $_pkg_arch)"
 arch=('any')
 url='https://www.openssl.org'
@@ -20,16 +21,23 @@ depends=('android-sdk' 'android-ndk')
 makedepends=('android-environment' 'android-sdk-build-tools')
 conflicts=("android-$_pkgname-$_android_arch")
 replaces=("android-$_pkgname-$_android_arch")
-source=("https://www.openssl.org/source/${_pkgname}-${_ver}.tar.gz"{,.asc})
+source=("https://www.openssl.org/source/${_pkgname}-${_ver}.tar.gz"{,.asc}
+       "${_patchname}.patch")
 sha256sums=('e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242'
-            'SKIP')
+            'SKIP'
+            '8ed3b78e8d6e5766595ae5ad6503cf0d21de4300d90aae556c7786f07ed9fdfb')
 validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491'
               '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C')
 
 build() {
-  cd "$srcdir/$_pkgname-$_ver"
+  cd "${srcdir}/${_pkgname}-${_ver}"
   source android-env ${_pkg_arch}
-  export PATH="$ANDROID_TOOLCHAIN/bin:$PATH"
+  export PATH="${ANDROID_TOOLCHAIN}/bin:${PATH}"
+
+  # Configure configuration script for android that shipped with openssl
+  # 1.1.1i does not account for the removal of the $ndk/platforms directory in
+  # android-ndk r22.
+  patch -Np1 < "${srcdir}/${_patchname}.patch"
 
   # don't use -mandroid flag (Clang as provided by the NDK does not like it)
   sed -i -e 's/-mandroid//' Configurations/15-android.conf
@@ -41,7 +49,7 @@ build() {
     -Wl,--no-allow-shlib-undefined \
     -Wl,--no-undefined \
     no-stdio \
-    no-ui \
+    no-ui-console \
     threads \
     shared \
     android-${_android_platform_arch##arch-}

--- a/openssl/android-x86/15-android_conf.patch
+++ b/openssl/android-x86/15-android_conf.patch
@@ -1,0 +1,217 @@
+diff --git a/Configurations/15-android.conf b/Configurations/15-android.conf
+index 4616394f8c..f3075e4b79 100644
+--- a/Configurations/15-android.conf
++++ b/Configurations/15-android.conf
+@@ -1,6 +1,6 @@
+ #### Android...
+ #
+-# See NOTES.ANDROID for details, and don't miss platform-specific
++# See NOTES-Android.md for details, and don't miss platform-specific
+ # comments below...
+ 
+ {
+@@ -24,23 +24,23 @@
+ 
+             my $ndk_var;
+             my $ndk;
+-            foreach (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
++            foreach (qw(ANDROID_NDK_ROOT ANDROID_NDK)) {
+                 $ndk_var = $_;
+                 $ndk = $ENV{$ndk_var};
+                 last if defined $ndk;
+             }
+-            die "\$ANDROID_NDK_HOME is not defined"  if (!$ndk);
+-            if (!-d "$ndk/platforms" && !-f "$ndk/AndroidVersion.txt") {
+-                # $ndk/platforms is traditional "all-inclusive" NDK, while
+-                # $ndk/AndroidVersion.txt is so-called standalone toolchain
+-                # tailored for specific target down to API level.
+-                die "\$ANDROID_NDK_HOME=$ndk is invalid";
++            die "\$ANDROID_NDK_ROOT is not defined"  if (!$ndk);
++            my $is_standalone_toolchain = -f "$ndk/AndroidVersion.txt";
++            my $ndk_src_props = "$ndk/source.properties";
++            my $is_ndk = -f $ndk_src_props;
++            if ($is_ndk == $is_standalone_toolchain) {
++                die "\$ANDROID_NDK_ROOT=$ndk is invalid";
+             }
+             $ndk = canonpath($ndk);
+ 
+             my $ndkver = undef;
+ 
+-            if (open my $fh, "<$ndk/source.properties") {
++            if (open my $fh, "<$ndk_src_props") {
+                 local $_;
+                 while(<$fh>) {
+                     if (m|Pkg\.Revision\s*=\s*([0-9]+)|) {
+@@ -59,7 +59,7 @@
+             if ($sysroot = $ENV{CROSS_SYSROOT}) {
+                 $sysroot =~ m|/android-([0-9]+)/arch-(\w+)/?$|;
+                 ($api, $arch) = ($1, $2);
+-            } elsif (-f "$ndk/AndroidVersion.txt") {
++            } elsif ($is_standalone_toolchain) {
+                 $sysroot = "$ndk/sysroot";
+             } else {
+                 $api = "*";
+@@ -72,17 +72,31 @@
+                     }
+                 }
+ 
+-                # list available platforms (numerically)
+-                my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
+-                                       $b =~ m/-([0-9]+)$/; $aa <=> $1;
+-                                     } glob("$ndk/platforms/android-$api");
+-                die "no $ndk/platforms/android-$api" if ($#platforms < 0);
++                if (-d "$ndk/platforms") {
++                    # list available platforms (numerically)
++                    my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
++                                           $b =~ m/-([0-9]+)$/; $aa <=> $1;
++                                         } glob("$ndk/platforms/android-$api");
++                    die "no $ndk/platforms/android-$api" if ($#platforms < 0);
+ 
+-                $sysroot = "@platforms[$#platforms]/arch-$arch";
+-                $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
+-                $api = $1;
++                    $sysroot = "@platforms[$#platforms]/arch-$arch";
++                    $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
++                    $api = $1;
++                } elsif ($api eq "*") {
++                    # r22 Removed platforms dir, use this JSON file
++                    my $path = "$ndk/meta/platforms.json";
++                    open my $fh, $path or die "Could not open '$path' $!";
++                    while (<$fh>) {
++                        if (/"max": (\d+),/) {
++                            $api = $1;
++                            last;
++                        }
++                    }
++                    close $fh;
++                }
++                die "Could not get default API Level" if ($api eq "*");
+             }
+-            die "no sysroot=$sysroot"   if (!-d $sysroot);
++            die "no sysroot=$sysroot" if (length $sysroot && !-d $sysroot);
+ 
+             my $triarch = $triplet{$arch};
+             my $cflags;
+@@ -95,17 +109,21 @@
+                 my $arm = $ndkver > 16 ? "armv7a" : "armv5te";
+                 (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
+                 (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
+-                $cflags .= " -target $tridefault "
+-                        .  "-gcc-toolchain \$($ndk_var)/toolchains"
+-                        .  "/$tritools-4.9/prebuilt/$host";
+-                $user{CC} = "clang" if ($user{CC} !~ m|clang|);
++                if (length $sysroot) {
++                    $cflags .= " -target $tridefault "
++                            .  "-gcc-toolchain \$($ndk_var)/toolchains"
++                            .  "/$tritools-4.9/prebuilt/$host";
++                    $user{CC} = "clang" if ($user{CC} !~ m|clang|);
++                } else {
++                    $user{CC} = "$tridefault$api-clang";
++                }
+                 $user{CROSS_COMPILE} = undef;
+                 if (which("llvm-ar") =~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
+                     $user{AR} = "llvm-ar";
+                     $user{ARFLAGS} = [ "rs" ];
+                     $user{RANLIB} = ":";
+                 }
+-            } elsif (-f "$ndk/AndroidVersion.txt") {    #"standalone toolchain"
++            } elsif ($is_standalone_toolchain) {
+                 my $cc = $user{CC} // "clang";
+                 # One can probably argue that both clang and gcc should be
+                 # probed, but support for "standalone toolchain" was added
+@@ -127,19 +145,21 @@
+                 $user{CROSS_COMPILE} = "$triarch-";
+             }
+ 
+-            if (!-d "$sysroot/usr/include") {
+-                my $incroot = "$ndk/sysroot/usr/include";
+-                die "no $incroot"          if (!-d $incroot);
+-                die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
+-                $incroot =~ s|^$ndk/||;
+-                $cppflags  = "-D__ANDROID_API__=$api";
+-                $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
+-                $cppflags .= " -isystem \$($ndk_var)/$incroot";
++            if (length $sysroot) {
++                if (!-d "$sysroot/usr/include") {
++                    my $incroot = "$ndk/sysroot/usr/include";
++                    die "no $incroot"          if (!-d $incroot);
++                    die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
++                    $incroot =~ s|^$ndk/||;
++                    $cppflags  = "-D__ANDROID_API__=$api";
++                    $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
++                    $cppflags .= " -isystem \$($ndk_var)/$incroot";
++                }
++                $sysroot =~ s|^$ndk/||;
++                $sysroot = " --sysroot=\$($ndk_var)/$sysroot";
+             }
+-
+-            $sysroot =~ s|^$ndk/||;
+             $android_ndk = {
+-                cflags   => "$cflags --sysroot=\$($ndk_var)/$sysroot",
++                cflags   => $cflags . $sysroot,
+                 cppflags => $cppflags,
+                 bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
+                                             : "BN_LLONG",
+@@ -168,7 +188,8 @@ my %targets = (
+         cppflags         => add(sub { android_ndk()->{cppflags} }),
+         cxxflags         => add(sub { android_ndk()->{cflags} }),
+         bn_ops           => sub { android_ndk()->{bn_ops} },
+-        bin_cflags       => "-pie",
++        bin_cflags       => "-fPIE",
++        bin_lflags       => "-pie",
+         enable           => [ ],
+     },
+     "android-arm" => {
+@@ -199,18 +220,22 @@ my %targets = (
+         # -march and/or -mfloat-abi flags. NDK defaults to armv5te.
+         # Newer NDK versions reportedly require additional -latomic.
+         #
+-        inherit_from     => [ "android", asm("armv4_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'armv4',
++        perlasm_scheme   => "void",
+     },
+     "android-arm64" => {
+-        inherit_from     => [ "android", asm("aarch64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'aarch64',
+         perlasm_scheme   => "linux64",
+     },
+ 
+     "android-mips" => {
+-        inherit_from     => [ "android", asm("mips32_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'mips32',
+         perlasm_scheme   => "o32",
+     },
+     "android-mips64" => {
+@@ -223,20 +248,23 @@ my %targets = (
+         # with previous MIPS ISA versions, in sense that unlike
+         # prior versions original MIPS binary code will fail.
+         #
+-        inherit_from     => [ "android", asm("mips64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_CHAR"),
++        asm_arch         => 'mips64',
+         perlasm_scheme   => "64",
+     },
+ 
+     "android-x86" => {
+-        inherit_from     => [ "android", asm("x86_asm") ],
++        inherit_from     => [ "android" ],
+         CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
+         bn_ops           => add("RC4_INT"),
++        asm_arch         => 'x86',
+         perlasm_scheme   => "android",
+     },
+     "android-x86_64" => {
+-        inherit_from     => [ "android", asm("x86_64_asm") ],
++        inherit_from     => [ "android" ],
+         bn_ops           => add("RC4_INT"),
++        asm_arch         => 'x86_64',
+         perlasm_scheme   => "elf",
+     },
+ 


### PR DESCRIPTION
The `Configure` configuration script for Android (i.e. `Configurations/15-android.conf`) in OpenSSL 1.1.1i incorrectly checks for the presence of `$ANDROID_NDK_HOME/platforms`. According to the [Chanelog for `android-ndk-r22`](https://github.com/android/ndk/wiki/Changelog-r22), the `$ANDROID_NDK_HOME/platforms` directory has been merged into `$ANDROID_NDK_HOME/toolchains`. The Android build configuration in `openssl/master` has been adjusted for `android-ndk-r22`. I have added a patch to align the stable OpenSSL used for the `android-*-openssl` packages with the configuration script in `openssl/master`.

I'm not sure if the upstream OpenSSL 1.1.1 branch will be updated to work with `android-ndk-r22`. Perhaps a bug against upstream is warranted...