### PR TITLE
Fix checksum and video load

### DIFF
--- a/subtitlecomposer/default/PKGBUILD
+++ b/subtitlecomposer/default/PKGBUILD
@@ -31,7 +31,7 @@ source=("https://download.kde.org/stable/${pkgname}/${_tar}.tar.xz"
         "https://invent.kde.org/multimedia/subtitlecomposer/-/commit/4f4f560e40ba0b760cf688eb024be3cc734ca347.patch")
 sha256sums=('ef9cb3c0c1fe1f40cf9d8e795859b9b28adf2da3be77a076d46bc28df4cd0255'
             'SKIP'
-	    '26197260a6e4419c7178c65a5ac9e8811418e40c97454b2aa8a62b149305dcd5')
+	          '012d89a4c3e328c0dca02a85113ac5f01b52a398de5dc2ed75d2d5d14b36886d')
 validpgpkeys=('76F79007A54A4B68F1547928E2418746EF9D9B26')
 
 prepare() {

--- a/subtitlecomposer/default/PKGBUILD
+++ b/subtitlecomposer/default/PKGBUILD
@@ -31,12 +31,14 @@ source=("https://download.kde.org/stable/${pkgname}/${_tar}.tar.xz"
         "https://invent.kde.org/multimedia/subtitlecomposer/-/commit/4f4f560e40ba0b760cf688eb024be3cc734ca347.patch")
 sha256sums=('ef9cb3c0c1fe1f40cf9d8e795859b9b28adf2da3be77a076d46bc28df4cd0255'
             'SKIP'
-	          '012d89a4c3e328c0dca02a85113ac5f01b52a398de5dc2ed75d2d5d14b36886d')
+            '012d89a4c3e328c0dca02a85113ac5f01b52a398de5dc2ed75d2d5d14b36886d'
+            '4044626bbd5682692cffd458be70313318f7e665f22df0fe7648acee28064aa1')
 validpgpkeys=('76F79007A54A4B68F1547928E2418746EF9D9B26')
 
 prepare() {
   cd "${srcdir}/${_tar}"
   patch -p1 -i "$srcdir/4f4f560e40ba0b760cf688eb024be3cc734ca347.patch"
+  patch -p1 -i "$srcdir/d8f9797d9c0d45fa9f4402f79c539544b74d2cc7.patch"
 }
 
 build() {


### PR DESCRIPTION
As pointed in https://github.com/Martchus/PKGBUILDs/issues/151, the checksum of the commit patch applied wasn't right and there was a commit published that enable to load video again.

There are two separate commits for each fix.