### PR TITLE
Support preset CMAKE_GENERATOR

### DIFF
--- a/bento4/default/PKGBUILD
+++ b/bento4/default/PKGBUILD
@@ -21,7 +21,7 @@ build() {
 
   sed -i "s/ STATIC / SHARED /" CMakeLists.txt
   cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="/usr" -DCMAKE_SKIP_BUILD_RPATH=ON
-  make
+  cmake --build .
 }
 
 package() {


### PR DESCRIPTION
In case this is set to 'Ninja' in user environment, build breaks calling 'make' directly. Instead use the cmake build command which takes the selected generator into account