### PR TITLE
Fix qt6-multimedia build on mingw-w64.

### DIFF
--- a/qt6-multimedia/mingw-w64-static/PKGBUILD
+++ b/qt6-multimedia/mingw-w64-static/PKGBUILD
@@ -32,6 +32,10 @@ prepare () {
     msg2 "Applying patch $patch"
     patch -p1 -i "$patch"
   done
+  # work around case-insensitive includes on case-sensitive filesystems
+  sed -i'' 's/\(.*\) \(Mf.*\|Propsys\) HINTS \(.*\)/\1 \L\2 HINTS \3/g' cmake/FindWMF.cmake
+  find src -type f -exec sed -i'' 's/#include <\(Dbt.*\|InitGuid.*\|Mf.*\|Wmcodec.*\|Functiondiscoverykeys_devpkey.*\)>/#include <\L\1>/g' {} \;
+  find src -type f -exec sed -i'' 's/#include "\(Dbt.*\|InitGuid.*\|Mf.*\|Wmcodec.*\|QUrl.*\)"/#include "\L\1"/g' {} \;
 }
 
 build() {

--- a/qt6-multimedia/mingw-w64/PKGBUILD
+++ b/qt6-multimedia/mingw-w64/PKGBUILD
@@ -32,6 +32,10 @@ prepare () {
     msg2 "Applying patch $patch"
     patch -p1 -i "$patch"
   done
+  # work around case-insensitive includes on case-sensitive filesystems
+  sed -i'' 's/\(.*\) \(Mf.*\|Propsys\) HINTS \(.*\)/\1 \L\2 HINTS \3/g' cmake/FindWMF.cmake
+  find src -type f -exec sed -i'' 's/#include <\(Dbt.*\|InitGuid.*\|Mf.*\|Wmcodec.*\|Functiondiscoverykeys_devpkey.*\)>/#include <\L\1>/g' {} \;
+  find src -type f -exec sed -i'' 's/#include "\(Dbt.*\|InitGuid.*\|Mf.*\|Wmcodec.*\|QUrl.*\)"/#include "\L\1"/g' {} \;
 }
 
 build() {

--- a/qt6-multimedia/mingw-w64/PKGBUILD.sh.ep
+++ b/qt6-multimedia/mingw-w64/PKGBUILD.sh.ep
@@ -20,3 +20,9 @@ makedepends=('mingw-w64-cmake<%== $static_suffix %>' <%== qt6deps qw(declarative
     #       Unfortunately it doesn't build as well (maybe it would using a newer mingw-w64 version).
     #       Disabling ffmpeg and gstreamer at this point explicitly due to lack of testing.\
 % end
+% content_for prepare => begin
+  # work around case-insensitive includes on case-sensitive filesystems
+  sed -i'' 's/\(.*\) \(Mf.*\|Propsys\) HINTS \(.*\)/\1 \L\2 HINTS \3/g' cmake/FindWMF.cmake
+  find src -type f -exec sed -i'' 's/#include <\(Dbt.*\|InitGuid.*\|Mf.*\|Wmcodec.*\|Functiondiscoverykeys_devpkey.*\)>/#include <\L\1>/g' {} \;
+  find src -type f -exec sed -i'' 's/#include "\(Dbt.*\|InitGuid.*\|Mf.*\|Wmcodec.*\|QUrl.*\)"/#include "\L\1"/g' {} \;
+%end


### PR DESCRIPTION
On Windows systems, several MediaFoundation library searches and includes in Qt6 Multimedia succeed because the file access is case-insensitive. On Linux, however, file access is usually case-sensitive, causing them to fail.

This PR fixes the build by selectively targeting these problematic includes and changing them to lowercase.

I've tested this in an Arch Linux WSL environment, would appreciate validation that the fix works on a real Arch Linux system as well as I had to change the source tar hash to get it to work.