### PR TITLE
gnutls: fix compile problem with gnutls.

### DIFF
--- a/gnutls/mingw-w64/PKGBUILD
+++ b/gnutls/mingw-w64/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Martchus <martchus@gmx.net>
 
 pkgname=mingw-w64-gnutls
-pkgver=3.7.8
+pkgver=3.8.1
 pkgrel=1
 pkgdesc='A library which provides a secure layer over a reliable transport layer (mingw-w64)'
 arch=('any')
@@ -14,11 +14,11 @@ options=(staticlibs !strip !buildflags)
 optdepends=("mingw-w64-openssl: libgnutls-openssl")
 source=(https://www.gnupg.org/ftp/gcrypt/gnutls/v${pkgver%.*}/${pkgname#mingw-w64-}-${pkgver}.tar.xz{,.sig}
         gnutls-fix-external-libtasn1-detection.patch)
-sha256sums=('c58ad39af0670efe6a8aee5e3a8b2331a1200418b64b7c51977fb396d4617114'
+sha256sums=('ba8b9e15ae20aba88f44661978f5b5863494316fe7e722ede9d069fe6294829c'
             'SKIP'
             '8525da75852a516be0cb05df0a770daf19ce0583033260d6cac03a1e40fd2072')
-#validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871') # "Daiki Ueno <ueno@unixuser.org>"
-validpgpkeys=('5D46CB0F763405A7053556F47A75A648B3F9220C') # "Zoltan Fridrich <zfridric@redhat.com>"
+validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871') # "Daiki Ueno <ueno@unixuser.org>"
+#validpgpkeys=('5D46CB0F763405A7053556F47A75A648B3F9220C') # "Zoltan Fridrich <zfridric@redhat.com>"
 
 _architectures='i686-w64-mingw32 x86_64-w64-mingw32'
 
@@ -28,6 +28,7 @@ prepare() {
   sed 's/gnutls_srp.c//g' -i lib/Makefile.in
   sed 's/gnutls_srp.lo//g' -i lib/Makefile.in
   rm -f lib/minitasn1/*.c lib/minitasn1/*.h
+  sed -i 's/gettime(/benchmark_gettime(/' 'src/benchmark.'{h,c}
 }
 
 build() {
@@ -42,13 +43,10 @@ build() {
       --disable-rpath \
       --disable-non-suiteb-curves \
       --disable-gtk-doc \
-      --disable-guile \
       --disable-full-test-suite \
       --with-libiconv-prefix=/usr/$_arch \
-      --with-regex-libs=-lsystre \
       --enable-nls \
       --enable-cxx \
-      --enable-local-libopts \
       --without-tpm
     make
     popd


### PR DESCRIPTION
Fix issue in #169 and also bump version to 3.8.1. We'll have to wait for an issue in `mingw-w64-p11-kit` to be resolved.