### PR TITLE
Add PKGBUILD for qtserialbus

### DIFF
--- a/qt5-serialbus/mingw-w64-static/PKGBUILD
+++ b/qt5-serialbus/mingw-w64-static/PKGBUILD
@@ -1,0 +1,117 @@
+# Maintainer: Martchus <martchus@gmx.net>
+# Contributor: Wolfgang Pupp <wolfgang.pupp@gmail.com>
+
+# All my PKGBUILDs are managed at https://github.com/Martchus/PKGBUILDs where
+# you also find the URL of a binary repository.
+
+# This file is created from PKGBUILD.sh.ep contained by the mentioned repository.
+# Do not edit it manually! See README.md in the repository's root directory
+# for more information.
+
+_qt_module=qtserialbus
+pkgname=mingw-w64-qt5-serialbus-static
+pkgver=5.15.13
+pkgrel=1
+arch=('any')
+pkgdesc="Qt module for general purpose serial bus access (mingw-w64)"
+depends=('mingw-w64-qt5-serialport-static')
+makedepends=('mingw-w64-gcc' 'mingw-w64-pkg-config')
+license=('GPL3' 'LGPL3' 'FDL' 'custom')
+_commit=5efce7d821bad2f5db95ff3ada5eeddccbb58920
+_basever=${pkgver%%+*}
+makedepends+=('git')
+options=('!strip' '!buildflags' 'staticlibs')
+groups=('mingw-w64-qt5')
+url='https://www.qt.io/'
+_pkgfqn=${_qt_module}
+source=(git+https://invent.kde.org/qt/qt/$_pkgfqn#commit=$_commit)
+sha256sums=('SKIP')
+
+_architectures='i686-w64-mingw32 x86_64-w64-mingw32'
+
+depends+=(${pkgname%-static}) # the static version relies on the shared version for build tools and headers
+_configurations+=('CONFIG+=no_smart_library_merge CONFIG+=static')
+
+pkgver() {
+  cd $_pkgfqn
+  echo "$_basever+kde+r"`git rev-list --count v$_basever-lts-lgpl..$_commit`
+}
+
+prepare() {
+  cd "${srcdir}/${_pkgfqn}"
+
+  # don't build examples or tests
+  sed -i 's/ examples tests//' qtserialbus.pro
+}
+
+build() {
+  cd "${srcdir}/${_pkgfqn}"
+
+  for _arch in ${_architectures}; do
+    for _config in "${_configurations[@]}"; do
+      msg2 "Building ${_config##*=} version for ${_arch}"
+      mkdir -p build-${_arch}-${_config##*=} && pushd build-${_arch}-${_config##*=}
+      ${_arch}-qmake-qt5 ../${_qt_module}.pro ${_config} ${_additional_qmake_args}
+      make
+      popd
+    done
+  done
+}
+
+package() {
+  cd "${srcdir}/${_pkgfqn}"
+
+  for _arch in ${_architectures}; do
+    for _config in "${_configurations[@]}"; do
+      pushd build-${_arch}-${_config##*=}
+
+      make INSTALL_ROOT="$pkgdir" install
+
+      # use prl files from build directory since installed prl files seem to have incorrect QMAKE_PRL_LIBS_FOR_CMAKE
+      if [[ -d 'lib' ]]; then
+        pushd 'lib'
+        find -iname '*.static.prl' -exec cp --target-directory "${pkgdir}/usr/${_arch}/lib" --parents {} +
+        popd
+      fi
+      if [[ -d 'plugins' ]]; then
+        pushd 'plugins'
+        find -iname '*.static.prl' -exec cp --target-directory "${pkgdir}/usr/${_arch}/lib/qt/plugins" --parents {} +
+        popd
+      fi
+
+      # replace library path in *.prl files so it points to the installed location and not the build directory
+      find "${pkgdir}/usr/${_arch}/lib" \( -type f -name '*.prl' -o -name '*.pc' \) -exec sed -i -e "s:$PWD/lib:/usr/$_arch/lib:g" {} \;
+
+      # remove prl files for debug version
+      if ! [[ $MINGW_W64_QT_DEBUG_BUILD ]]; then
+        for file in $(find "${pkgdir}/usr/${_arch}" -name '*d.prl' -o -name '*d.static.prl'); do
+          [ -f "${file%d*}${file##*d}" ] && rm "${file}";
+        done
+      fi
+
+      # remove '.static.prl' files
+      find "${pkgdir}/usr/${_arch}" -name '.static.prl' -delete
+
+      # delete duplicate files that are in the shared package
+      find "${pkgdir}/usr/${_arch}" -name '*.exe' -delete
+      for shared_path in "${pkgdir}/usr/${_arch}/"{include,share} "${pkgdir}/usr/${_arch}/lib/"{qt/bin,qt/mkspecs}; do
+        [[ -d $shared_path ]] && rm -fR "$shared_path"
+      done
+      for file in $(find "$pkgdir/usr/$_arch/lib"); do
+        [[ -f "${file##$pkgdir}" ]] && rm "$file"
+      done
+
+      find "${pkgdir}/usr/${_arch}/lib" -maxdepth 1 -name '*.dll' -delete
+      find "${pkgdir}/usr/${_arch}" -name '*.dll' -exec ${_arch}-strip --strip-unneeded {} \;
+      find "${pkgdir}/usr/${_arch}" \( -name '*.a' -not -name 'libQt5QmlDevTools.a' -not -name 'libQt5Bootstrap.a' \) -exec ${_arch}-strip -g {} \;
+      [[ -d "${pkgdir}/usr/${_arch}/lib/qt/bin/" ]] && \
+        find "${pkgdir}/usr/${_arch}/lib/qt/bin/" -exec strip --strip-all {} \;
+      find "${pkgdir}/usr/${_arch}/lib/" -iname "*.so.$pkgver" -exec strip --strip-unneeded {} \;
+      popd
+    done
+
+    # drop QMAKE_PRL_BUILD_DIR because reference the build dir
+    find "${pkgdir}/usr/${_arch}/lib" -type f -name '*.prl' -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+  done
+}
+

--- a/qt5-serialbus/mingw-w64-static/PKGBUILD.sh.ep
+++ b/qt5-serialbus/mingw-w64-static/PKGBUILD.sh.ep
@@ -1,0 +1,1 @@
+%= include "$default_package_name/mingw-w64/PKGBUILD";

--- a/qt5-serialbus/mingw-w64/PKGBUILD
+++ b/qt5-serialbus/mingw-w64/PKGBUILD
@@ -1,0 +1,109 @@
+# Maintainer: Martchus <martchus@gmx.net>
+# Contributor: Wolfgang Pupp <wolfgang.pupp@gmail.com>
+
+# All my PKGBUILDs are managed at https://github.com/Martchus/PKGBUILDs where
+# you also find the URL of a binary repository.
+
+# This file is created from PKGBUILD.sh.ep contained by the mentioned repository.
+# Do not edit it manually! See README.md in the repository's root directory
+# for more information.
+
+_qt_module=qtserialbus
+pkgname=mingw-w64-qt5-serialbus
+pkgver=5.15.13
+pkgrel=1
+arch=('any')
+pkgdesc="Qt module for general purpose serial bus access (mingw-w64)"
+depends=('mingw-w64-qt5-serialport')
+makedepends=('mingw-w64-gcc' 'mingw-w64-pkg-config')
+license=('GPL3' 'LGPL3' 'FDL' 'custom')
+_commit=5efce7d821bad2f5db95ff3ada5eeddccbb58920
+_basever=${pkgver%%+*}
+makedepends+=('git')
+options=('!strip' '!buildflags' 'staticlibs')
+groups=('mingw-w64-qt5')
+url='https://www.qt.io/'
+_pkgfqn=${_qt_module}
+source=(git+https://invent.kde.org/qt/qt/$_pkgfqn#commit=$_commit)
+sha256sums=('SKIP')
+
+_architectures='i686-w64-mingw32 x86_64-w64-mingw32'
+
+_configurations+=('CONFIG+=actually_a_shared_build CONFIG+=shared')
+
+pkgver() {
+  cd $_pkgfqn
+  echo "$_basever+kde+r"`git rev-list --count v$_basever-lts-lgpl..$_commit`
+}
+
+prepare() {
+  cd "${srcdir}/${_pkgfqn}"
+
+  # don't build examples or tests
+  sed -i 's/ examples tests//' qtserialbus.pro
+}
+
+build() {
+  cd "${srcdir}/${_pkgfqn}"
+
+  for _arch in ${_architectures}; do
+    for _config in "${_configurations[@]}"; do
+      msg2 "Building ${_config##*=} version for ${_arch}"
+      mkdir -p build-${_arch}-${_config##*=} && pushd build-${_arch}-${_config##*=}
+      ${_arch}-qmake-qt5 ../${_qt_module}.pro ${_config} ${_additional_qmake_args}
+      make
+      popd
+    done
+  done
+}
+
+package() {
+  cd "${srcdir}/${_pkgfqn}"
+
+  for _arch in ${_architectures}; do
+    for _config in "${_configurations[@]}"; do
+      pushd build-${_arch}-${_config##*=}
+
+      make INSTALL_ROOT="$pkgdir" install
+
+      # use prl files from build directory since installed prl files seem to have incorrect QMAKE_PRL_LIBS_FOR_CMAKE
+      if [[ -d 'lib' ]]; then
+        pushd 'lib'
+        find -iname '*.static.prl' -exec cp --target-directory "${pkgdir}/usr/${_arch}/lib" --parents {} +
+        popd
+      fi
+      if [[ -d 'plugins' ]]; then
+        pushd 'plugins'
+        find -iname '*.static.prl' -exec cp --target-directory "${pkgdir}/usr/${_arch}/lib/qt/plugins" --parents {} +
+        popd
+      fi
+
+      # replace library path in *.prl files so it points to the installed location and not the build directory
+      find "${pkgdir}/usr/${_arch}/lib" \( -type f -name '*.prl' -o -name '*.pc' \) -exec sed -i -e "s:$PWD/lib:/usr/$_arch/lib:g" {} \;
+
+      # remove prl files for debug version
+      if ! [[ $MINGW_W64_QT_DEBUG_BUILD ]]; then
+        for file in $(find "${pkgdir}/usr/${_arch}" -name '*d.prl' -o -name '*d.static.prl'); do
+          [ -f "${file%d*}${file##*d}" ] && rm "${file}";
+        done
+      fi
+
+      # remove '.static.prl' files
+      find "${pkgdir}/usr/${_arch}" -name '.static.prl' -delete
+
+      find "${pkgdir}/usr/${_arch}/lib" -maxdepth 1 -name '*.dll' -delete
+      [ "$NO_STATIC_EXECUTABLES" -a "${_config##*=}" = static -o "$NO_EXECUTABLES" ] && \
+        find "${pkgdir}/usr/${_arch}" -name '*.exe' -delete || \
+        find "${pkgdir}/usr/${_arch}" -name '*.exe' -exec ${_arch}-strip --strip-all {} \;
+      find "${pkgdir}/usr/${_arch}" -name '*.dll' -exec ${_arch}-strip --strip-unneeded {} \;
+      find "${pkgdir}/usr/${_arch}" \( -name '*.a' -not -name 'libQt5QmlDevTools.a' -not -name 'libQt5Bootstrap.a' \) -exec ${_arch}-strip -g {} \;
+      [[ -d "${pkgdir}/usr/${_arch}/lib/qt/bin/" ]] && \
+        find "${pkgdir}/usr/${_arch}/lib/qt/bin/" -exec strip --strip-all {} \;
+      find "${pkgdir}/usr/${_arch}/lib/" -iname "*.so.$pkgver" -exec strip --strip-unneeded {} \;
+      popd
+    done
+
+    # drop QMAKE_PRL_BUILD_DIR because reference the build dir
+    find "${pkgdir}/usr/${_arch}/lib" -type f -name '*.prl' -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+  done
+}

--- a/qt5-serialbus/mingw-w64/PKGBUILD.sh.ep
+++ b/qt5-serialbus/mingw-w64/PKGBUILD.sh.ep
@@ -1,0 +1,19 @@
+% layout 'mingw-w64-qt5-module';
+\
+% content_for additional_contributors => begin
+# Contributor: Wolfgang Pupp <wolfgang.pupp@gmail.com>
+% end
+\
+pkgver=5.15.13
+pkgrel=1
+arch=('any')
+pkgdesc="Qt module for general purpose serial bus access (mingw-w64)"
+depends=(<%== qt5deps qw(serialport) %>)
+makedepends=('mingw-w64-gcc' 'mingw-w64-pkg-config')
+license=('GPL3' 'LGPL3' 'FDL' 'custom')
+\
+% content_for prepare => begin
+
+  # don't build examples or tests
+  sed -i 's/ examples tests//' qtserialbus.pro
+% end


### PR DESCRIPTION
This adds mingw-w64-qt5-serialbus as package, which is currently only available for Qt-6.
