### PR TITLE
Use temporary directory as HOME for syncthingtray tests

### DIFF
--- a/syncthingtray/default/PKGBUILD
+++ b/syncthingtray/default/PKGBUILD
@@ -74,8 +74,8 @@ build() {
 
 check() {
   cd "$srcdir/${PROJECT_DIR_NAME:-$_reponame-$pkgver}"
-  export HOME=${HOME:-/}  # https://github.com/syncthing/syncthing/issues/8785
-  QT_QPA_PLATFORM=offscreen SYNCTHING_PORT=$(ephemeral_port) SYNCTHING_TEST_TIMEOUT_FACTOR=3 ninja check
+  # https://github.com/syncthing/syncthing/issues/8785
+  HOME="$(mktemp -p . -d testhome.XXX)" QT_QPA_PLATFORM=offscreen SYNCTHING_PORT=$(ephemeral_port) SYNCTHING_TEST_TIMEOUT_FACTOR=3 ninja check
 }
 
 package() {

--- a/syncthingtray/git/PKGBUILD
+++ b/syncthingtray/git/PKGBUILD
@@ -92,8 +92,8 @@ build() {
 
 check() {
   cd "$srcdir/${PROJECT_DIR_NAME:-$_reponame}"
-  export HOME=${HOME:-/}  # https://github.com/syncthing/syncthing/issues/8785
-  QT_QPA_PLATFORM=offscreen SYNCTHING_PORT=$(ephemeral_port) SYNCTHING_TEST_TIMEOUT_FACTOR=3 ninja check
+  # https://github.com/syncthing/syncthing/issues/8785
+  HOME="$(mktemp -p . -d testhome.XXX)" QT_QPA_PLATFORM=offscreen SYNCTHING_PORT=$(ephemeral_port) SYNCTHING_TEST_TIMEOUT_FACTOR=3 ninja check
 }
 
 package() {

--- a/syncthingtray/qt6/PKGBUILD
+++ b/syncthingtray/qt6/PKGBUILD
@@ -92,8 +92,8 @@ build() {
 
 check() {
   cd "$srcdir/${PROJECT_DIR_NAME:-$_reponame-$pkgver}"
-  export HOME=${HOME:-/}  # https://github.com/syncthing/syncthing/issues/8785
-  QT_QPA_PLATFORM=offscreen SYNCTHING_PORT=$(ephemeral_port) SYNCTHING_TEST_TIMEOUT_FACTOR=3 ninja check
+  # https://github.com/syncthing/syncthing/issues/8785
+  HOME="$(mktemp -p . -d testhome.XXX)" QT_QPA_PLATFORM=offscreen SYNCTHING_PORT=$(ephemeral_port) SYNCTHING_TEST_TIMEOUT_FACTOR=3 ninja check
 }
 
 package() {

--- a/syncthingtray/static-compat/PKGBUILD
+++ b/syncthingtray/static-compat/PKGBUILD
@@ -124,8 +124,8 @@ check() {
   source static-compat-environment
   export PATH=$PWD:$PATH
   cd "$srcdir/${PROJECT_DIR_NAME:-$_reponame-$pkgver}"
-  export HOME=${HOME:-/}  # https://github.com/syncthing/syncthing/issues/8785
-  QT_QPA_PLATFORM=offscreen SYNCTHING_PORT=$(ephemeral_port) SYNCTHING_TEST_TIMEOUT_FACTOR=3 ninja check
+  # https://github.com/syncthing/syncthing/issues/8785
+  HOME="$(mktemp -p . -d testhome.XXX)" QT_QPA_PLATFORM=offscreen SYNCTHING_PORT=$(ephemeral_port) SYNCTHING_TEST_TIMEOUT_FACTOR=3 ninja check
 }
 
 package() {


### PR DESCRIPTION
Some part of the syncthingtray or syncthing tests creates a Sync directory under $HOME if it doesn't exist.  This can be annoying for users building or testing the package when they don't use the default $HOME/Sync directory as it leaves behind cruft in their home.

Use a temporary directory when testing instead.  Don't export the variable in case the overridden $HOME leaks into other parts of the build process.

This same issue probably exists in the other variants as well, but I haven't tested those so I'll leave that for a followup.