### PR TITLE
Allow php-legacy to satisfy PHP dependency

### DIFF
--- a/baikal/default/PKGBUILD
+++ b/baikal/default/PKGBUILD
@@ -8,8 +8,8 @@ pkgdesc='Lightweight CalDAV+CardDAV server'
 url='http://sabre.io/baikal/'
 arch=('any')
 license=(GPL-3.0-only)
-depends=('php')
-optdepends=('sqlite: Database' 'mariadb: Alternate database' 'php-sqlite: To use the sqlite backend')
+depends=('php-interpreter')
+optdepends=('mariadb: Alternate database' 'php-sqlite-interpreter: To use the sqlite backend')
 source=("https://github.com/fruux/Baikal/releases/download/$pkgver/baikal-$pkgver.zip"
         'baikal.install')
 sha512sums=('b17c3a8b1b20c3cfa5977978391b9319aba252adcf9718376d5e3d9cda222cd32f0ff33646bd258687bbbc1dfb27485567ffa80251fa4421e8f42b9372011928'

--- a/baikal/default/baikal.install
+++ b/baikal/default/baikal.install
@@ -1,7 +1,8 @@
 # Maintainer: Florian Bruhin (The Compiler) <archlinux.org@the-compiler.org>
 
 post_install() {
-  echo "Please add /var/lib/baikal to open_basedir in your /etc/php/php.ini."
+  echo "Please add /var/lib/baikal to open_basedir in your php.ini (e.g."
+  echo "/etc/php/php.ini or /etc/php-legacy/php.ini)."
   echo
   echo "You also need to set up your webserver for baikal, there are example"
   echo "configs for Apache/nginx at http://sabre.io/baikal/install/."
@@ -11,7 +12,8 @@ post_install() {
 
 post_upgrade() {
   if [[ $(vercmp $2 '0.2.7-5') == -1 ]]; then
-    echo "Please add /var/lib/baikal to open_basedir in your /etc/php.ini."
+    echo "Please add /var/lib/baikal to open_basedir in your php.ini (e.g."
+    echo "/etc/php/php.ini or /etc/php-legacy/php.ini)."
   fi
   echo "Navigate to your baikal admin interface to complete the upgrade."
 }


### PR DESCRIPTION
Also remove direct dependency on sqlite; the transitive dependency via php-sqlite-interpreter is more appropriate.

As `php-legacy` is always one feature version behind the latest, it should always be compatible with Baikal, making it a useful alternative.