### PR TITLE
Add --disable-tcl to sqlite configure (mingw)

### DIFF
--- a/sqlite/mingw-w64/PKGBUILD
+++ b/sqlite/mingw-w64/PKGBUILD
@@ -48,6 +48,7 @@ build() {
     # remove '--target=...' from mingw's configure
     bash <(sed 's/--target[^ ]* //' $(command -v "${_arch}-configure")) \
       --enable-fts3 \
+      --disable-tcl \
       --fts4 \
       --fts5 \
       --rtree \


### PR DESCRIPTION
This adds `--disable-tcl` to the PKGBUILD for mingw-w64-sqlite. It fails to build with tcl enabled (if tcl is installed). See #201 