### PR TITLE
python-pocketsphinx: keep debug info

### DIFF
--- a/pocketsphinx/default/PKGBUILD
+++ b/pocketsphinx/default/PKGBUILD
@@ -25,7 +25,7 @@ build() {
 
   cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=ON -DBUILD_GSTREAMER=ON
   cmake --build build
-  python -m build --wheel --no-isolation
+  python -m build --wheel --no-isolation -Cinstall.strip=false
 }
 
 package_pocketsphinx() {


### PR DESCRIPTION
Stripping is enabled by default in scikit-build. This option disables that so that makepkg handles splitting and stripping debug information. See https://scikit-build-core.readthedocs.io/en/latest/configuration

---

Resolves this when building with `options=(strip debug)`:

```log
==> Tidying install...
  -> Removing libtool files...
  -> Removing static library files...
  -> Purging unwanted files...
  -> Removing empty directories...
  -> Stripping unneeded symbols from binaries and libraries...
Error while writing index for `/build/pocketsphinx/pkg/python-pocketsphinx/usr/lib/python3.14/site-packages/pocketsphinx/_pocketsphinx.cpython-314-x86_64-linux-gnu.so': No debugging symbols
gdb-add-index: No index was created for ./usr/lib/python3.14/site-packages/pocketsphinx/_pocketsphinx.cpython-314-x86_64-linux-gnu.so
gdb-add-index: [Was there no debuginfo? Was there already an index?]
  -> Compressing man and info pages...
```